### PR TITLE
Document exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ JavaScript project - for example:
 docker run --rm -v $(pwd):/project ericornelissen/js-re-scan:latest
 ```
 
+### Exit codes
+
+The scanner has the following exit codes.
+
+| Exit code | Meaning                                          |
+| --------: | :----------------------------------------------- |
+| 0         | No problems were found                           |
+| 1         | Files with problematic regular expressions found |
+| 2         | Something went wrong while scanning              |
+
 ## Features
 
 - Detect cases of exponential and polynomial backtracking.


### PR DESCRIPTION
Closes #3 

---

### Summary

Adds documentation for the exit codes of the scanner. This is based on a the [ESLint documentation for exit codes](https://eslint.org/docs/latest/user-guide/command-line-interface#exit-codes) and backed by experimentation with the scanner. Compared to the ESLint docs, the descriptions of the exit codes are adapted to make sense for this project.