### PR TITLE
Ignore more directories when scanning

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -40,6 +40,7 @@ ignorePatterns:
   - "bower_components/**"
   - "jspm_packages/**"
   - "node_modules/**"
+  - "vendor/**"
   - "web_modules/**"
 
   # IDE directories

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -24,4 +24,35 @@ overrides:
     parser: "@typescript-eslint/parser"
 
 ignorePatterns:
+  # Cache/temp directories
+  - ".cache/**"
+  - ".npm/**"
+  - ".parcel-cache/**"
+  - ".rpt2_cache/**"
+  - ".rts2_cache_cjs/**"
+  - ".rts2_cache_es/**"
+  - ".rts2_cache_umd/**"
+  - ".temp/**"
+  - ".yarn/cache/**"
+  - ".yarn/unplugged/**"
+
+  # Dependency directories
+  - "bower_components/**"
+  - "jspm_packages/**"
   - "node_modules/**"
+  - "web_modules/**"
+
+  # Output directories
+  - ".docusaurus/**"
+  - ".fusebox/**"
+  - ".dynamodb/**"
+  - ".grunt/**"
+  - ".next/**"
+  - ".nuxt/**"
+  - ".nyc_output/**"
+  - ".serverless/**"
+  - ".vuepress/dist/**"
+  - "coverage/**"
+  - "dist/**"
+  - "lib-cov/**"
+  - "out/**"

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -42,6 +42,10 @@ ignorePatterns:
   - "node_modules/**"
   - "web_modules/**"
 
+  # IDE directories
+  - ".idea/**"
+  - ".vscode/**"
+
   # Output directories
   - ".docusaurus/**"
   - ".fusebox/**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning].
 
 - (`9d2829c`) Add support for scanning TypeScript projects.
 - (`3aebaf0`) Bump ESLint from `8.23.0` to `8.23.1`.
+- (`8d5b874`) Ignore more dependency as well as common output/temporary folders.
+- (`1353931`) Ignore IDE related folders.
+- (`8863b7b`) Ignore the `vendor/` folder.
 
 ## [0.1.1] - 2022-09-17
 


### PR DESCRIPTION
Closes #12 

---

### Summary

Expands the list of directories ignored by ESLint to include more stuff that is probably not relevant - and thus likely would only result in noise for users of the scanner.

The ignored directories are either:

- Directories created by IDEs (everything under `# IDE directories`); or
- The dependency directory named `vendor/`; or
- Based on [GitHub's `Node.gitignore` template](https://github.com/github/gitignore/blob/e5323759e387ba347a9d50f8b0ddd16502eb71d4/Node.gitignore).