### PR TITLE
Add initial `LABEL`s to the Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`4c29319`) Add labels with metadata to the Docker image.
 
 ## [0.2.0] - 2022-09-21
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,11 @@
 
 FROM node:18.9.0-alpine3.15
 
+LABEL name="js-regex-security-scanner" \
+	description="A static analyzer to scan JavaScript code for problematic regular expressions." \
+	version="0.2.0" \
+	license="Apache-2.0"
+
 WORKDIR /home/node/js-re-scan
 
 COPY package.json package-lock.json ./

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "js-regex-security-scanner",
+  "description": "A static analyzer to scan JavaScript code for problematic regular expressions.",
   "version": "0.2.0",
   "type": "module",
   "private": true,


### PR DESCRIPTION
Closes #17

---

### Summary

This adds some initial `LABEL`s with metadata about the scanner to the image. The chosen fields were taken from the related issue.

The `LABEL`s were given the following values:

- `name`: The name of the scanner, equal to the name defined in `package.json::name`.
- `description`: A description of the scanner, taken from `README.md`(line 3).
- `version`: The current version of the scanner. Like `package.json::version`, without a leading "v".
- `license`: The SPDX license ID of the license under which the scanner is released.

Additionally, this adds the metadata (now) present in the `Dockerfile` that was previously not in `package.json` to `package.json`.