### PR TITLE
Replace Snyk scan with Syft & Grype

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,5 @@ jobs:
         ref:
           - main
           - v0
-    secrets:
-      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     with:
       ref: ${{ matrix.ref }}

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -5,9 +5,6 @@ on:
       ref:
         required: false
         type: string
-    secrets:
-      SNYK_TOKEN:
-        required: true
 
 permissions: read-all
 

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -15,20 +15,33 @@ jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
+    env:
+      SBOM_FILE: sbom.json
+      VULN_FILE: vulns.json
     steps:
       - name: Checkout Code
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           ref: ${{ inputs.ref }}
+      - name: Download Syft and Grype
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b ./bin v0.57.0
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh  | sh -s -- -b ./bin v0.50.2
       - name: Build
         run: docker build --tag ericornelissen/js-re-scan .
-      - name: Audit Docker image
-        uses: snyk/actions/docker@7fad562681122205233d1242c3bb39598c5393da
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      - name: Create SBOM
+        run: |
+          ./bin/syft ericornelissen/js-re-scan:latest -o json > ${{ env.SBOM_FILE }}
+      - name: Scan SBOM
+        run: |
+          ./bin/grype ${{ env.SBOM_FILE }} -o json > ${{ env.VULN_FILE }}
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
         with:
-          args: --file=Dockerfile
-          image: ericornelissen/js-re-scan
+          if-no-files-found: error
+          name: container-scan
+          path: |
+            ${{ env.SBOM_FILE }}
+            ${{ env.VULN_FILE }}
   npm:
     name: npm
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -31,7 +31,7 @@ jobs:
         run: docker build --tag ericornelissen/js-re-scan .
       - name: Create SBOM
         run: |
-          ./bin/syft ericornelissen/js-re-scan:latest -o json > ${{ env.SBOM_FILE }}
+          ./bin/syft ericornelissen/js-re-scan:latest
       - name: Scan SBOM
         run: |
           ./bin/grype ${{ env.SBOM_FILE }} -o json > ${{ env.VULN_FILE }}

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -34,8 +34,10 @@ jobs:
           ./bin/syft ericornelissen/js-re-scan:latest
       - name: Scan SBOM
         run: |
-          ./bin/grype ${{ env.SBOM_FILE }} -o json > ${{ env.VULN_FILE }}
-      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
+          ./bin/grype ${{ env.SBOM_FILE }}
+      - name: Upload SBOM and vulnerability scan
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
+        if: ${{ always() }}
         with:
           if-no-files-found: error
           name: container-scan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ permissions: read-all
 jobs:
   audit:
     name: Audit
-    uses: ericcornelissen/js-regex-security-scanner/.github/workflows/reusable-audit.yml@main
+    uses: ericcornelissen/js-regex-security-scanner/.github/workflows/reusable-audit.yml@10-use-syft-and-grype
     needs:
       - build
     secrets:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,6 @@ jobs:
     uses: ericcornelissen/js-regex-security-scanner/.github/workflows/reusable-audit.yml@10-use-syft-and-grype
     needs:
       - build
-    secrets:
-      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ npm-debug.log*
 
 # ESLint
 .eslintcache
+
+# Syft & Grype
+sbom.json
+vulns.json

--- a/.grype.yml
+++ b/.grype.yml
@@ -1,0 +1,42 @@
+# Check out Grype at: https://github.com/anchore/grype
+
+ignore:
+  # Ignored because the CVE is not for the npm package named "slash".
+  - vulnerability: CVE-2002-1647
+    fix-state: unknown
+    package:
+      name: slash
+      language: javascript
+      type: npm
+
+  # Ignored because the CVE is not for the npm package named "opener".
+  - vulnerability: CVE-2021-27482
+    fix-state: unknown
+    package:
+      name: opener
+      language: javascript
+      type: npm
+
+  # Ignored because the CVE is not for the npm package named "opener".
+  - vulnerability: CVE-2021-27498
+    fix-state: unknown
+    package:
+      name: opener
+      language: javascript
+      type: npm
+
+  # Ignored because the CVE is not for the npm package named "opener".
+  - vulnerability: CVE-2021-27500
+    fix-state: unknown
+    package:
+      name: opener
+      language: javascript
+      type: npm
+
+  # Ignored because the CVE is not for the npm package named "opener".
+  - vulnerability: CVE-2021-27478
+    fix-state: unknown
+    package:
+      name: opener
+      language: javascript
+      type: npm

--- a/.grype.yml
+++ b/.grype.yml
@@ -1,5 +1,10 @@
 # Check out Grype at: https://github.com/anchore/grype
 
+output: json
+file: vulns.json
+
+fail-on-severity: low
+
 ignore:
   # Ignored because the CVE is not for the npm package named "slash".
   - vulnerability: CVE-2002-1647

--- a/.grype.yml
+++ b/.grype.yml
@@ -6,42 +6,6 @@ file: vulns.json
 fail-on-severity: low
 
 ignore:
-  # Ignored because the CVE is not for the npm package named "slash".
-  - vulnerability: CVE-2002-1647
-    fix-state: unknown
-    package:
-      name: slash
-      language: javascript
-      type: npm
-
-  # Ignored because the CVE is not for the npm package named "opener".
-  - vulnerability: CVE-2021-27482
-    fix-state: unknown
-    package:
-      name: opener
-      language: javascript
-      type: npm
-
-  # Ignored because the CVE is not for the npm package named "opener".
-  - vulnerability: CVE-2021-27498
-    fix-state: unknown
-    package:
-      name: opener
-      language: javascript
-      type: npm
-
-  # Ignored because the CVE is not for the npm package named "opener".
-  - vulnerability: CVE-2021-27500
-    fix-state: unknown
-    package:
-      name: opener
-      language: javascript
-      type: npm
-
-  # Ignored because the CVE is not for the npm package named "opener".
-  - vulnerability: CVE-2021-27478
-    fix-state: unknown
-    package:
-      name: opener
-      language: javascript
+  # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
+  - package:
       type: npm

--- a/.syft.yml
+++ b/.syft.yml
@@ -1,0 +1,4 @@
+# Check out Syft at: https://github.com/anchore/syft
+
+output:
+  - json=sbom.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,9 @@ To generate the SBOM at `./sbom.json`, run:
 
 ### Vulnerability Scanning
 
-To scan for vulnerabilities, make sure you:
+#### Docker
+
+To scan for vulnerabilities in the Docker image, make sure you:
 
 - Have generated the project's SBOM.
 - Have [Grype] installed, you can run:
@@ -194,6 +196,14 @@ To generate a vulnerability report at `./vulns.json`, run:
 
 ```shell
 ./bin/grype sbom.json
+```
+
+#### Node.js
+
+To scan for vulnerabilities in Node.js dependencies, run:
+
+```shell
+npm audit
 ```
 
 [ava]: https://github.com/avajs/ava

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,46 @@ To write a test you need to do three things:
 1. Run the tests, this will automatically initialize the snapshot for the new
    test.
 
+---
+
+## Auditing
+
+### SBOM
+
+To be able to generate a Software Bill Of Materials (SBOM), make sure you:
+
+- Have build the [Docker] image of the scanner locally.
+- Have [Syft] installed, you can run:
+
+  ```shell
+  curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | \
+    sh -s -- -b ./bin v0.57.0
+  ```
+
+To generate the SBOM at `./sbom.json`, run:
+
+```shell
+./bin/syft ericornelissen/js-re-scan:latest
+```
+
+### Vulnerability Scanning
+
+To scan for vulnerabilities, make sure you:
+
+- Have generated the project's SBOM.
+- Have [Grype] installed, you can run:
+
+  ```shell
+  curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | \
+    sh -s -- -b ./bin v0.50.2
+  ```
+
+To generate a vulnerability report at `./vulns.json`, run:
+
+```shell
+./bin/grype sbom.json
+```
+
 [ava]: https://github.com/avajs/ava
 [bug report]: https://github.com/ericcornelissen/js-regex-security-scanner/issues/new?labels=bug
 [docker]: https://www.docker.com/
@@ -163,8 +203,10 @@ To write a test you need to do three things:
 [eslint]: https://eslint.org/
 [feature request]: https://github.com/ericcornelissen/js-regex-security-scanner/issues/new?labels=enhancement
 [git]: https://git-scm.com/
+[grype]: https://github.com/anchore/grype
 [node.js]: https://nodejs.org/en/
 [npm]: https://www.npmjs.com/
 [open issues]: https://github.com/ericcornelissen/js-regex-security-scanner/issues
 [security policy]: ./SECURITY.md
 [submodule]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
+[syft]: https://github.com/anchore/syft

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,6 @@
+# Binaries shouldn't be tracked in version control. This .gitignore exists to
+# ensure 1) this directory exists, avoiding potential problems when trying to
+# put files in it, and 2) no binaries are ever committed.
+
+*
+!.gitignore


### PR DESCRIPTION
Relates to #10
Partially reverts #16

---

### Summary

Replace the Snyk scan in the CI by combining [Syft] and [Grype] to do Software Bill Of Materials (SBOM) creation and vulnerability scanning (resp.). The main motivation for this change is that the latter two are open source, making it easier for contributors to run these tools locally as well. On top of that, this also provides a text-based SBOM for the scanner.

Both the SBOM and vulnerabilities output are uploaded as artifacts for quick consumption, in particular on Pull Requests (in contrast to having to pull and run [Syft] and [Grype] locally.

Note that [Grype] does not appear to be great at telling if a CVE really belongs to a particular dependency. All CVEs detected by [Grype] at the time of writing are for dependencies in different ecosystems, just with the same name. This, however, is a fine trade-off as such false positives can be ignored effectively.

[Syft]: https://github.com/anchore/syft
[Grype]: https://github.com/anchore/grype