### PR TITLE
Only audit production dependencies for version refs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   audit:
     name: Audit (${{ matrix.ref }})
-    uses: ericcornelissen/js-regex-security-scanner/.github/workflows/reusable-audit.yml@main
+    uses: ericcornelissen/js-regex-security-scanner/.github/workflows/reusable-audit.yml@10-dont-audit-dev-deps-for-releases
     strategy:
       matrix:
         ref:

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -44,5 +44,9 @@ jobs:
           cache: npm
       - name: Install Node.js dependencies
         run: npm ci
-      - name: Audit npm dependencies
+      - name: Audit all npm dependencies
+        if: ${{ !startsWith(inputs.ref, 'v') }}
         run: npm audit
+      - name: Audit production npm dependencies
+        if: ${{ startsWith(inputs.ref, 'v') }}
+        run: npm audit --omit dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ permissions: read-all
 jobs:
   audit:
     name: Audit
-    uses: ericcornelissen/js-regex-security-scanner/.github/workflows/reusable-audit.yml@main
+    uses: ericcornelissen/js-regex-security-scanner/.github/workflows/reusable-audit.yml@10-dont-audit-dev-deps-for-releases
     needs:
       - build
     secrets:


### PR DESCRIPTION
Relates to #10

---

### Summary

This is done to avoid warnings about development dependencies that may have already been resolved (e.g. on `main)` but not yet released. As development dependencies don't affect the released scanner, warnings about them are pointless at best (and noisy at worst).

This was implemented within the reusable workflow to reduce changes and avoid introducing similar noise if the workflow is used in a different way in the future.

The effect of this change can be observed in:

- [`test.yml` workflow run](https://github.com/ericcornelissen/js-regex-security-scanner/actions/runs/3118345498)
- [`nightly.yml` workflow run](https://github.com/ericcornelissen/js-regex-security-scanner/actions/runs/3118346454)