### PR TITLE
Ensure all scanner-related files are owned by non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,17 @@ LABEL name="js-regex-security-scanner" \
 	version="0.2.0" \
 	license="Apache-2.0"
 
+USER node:node
+RUN mkdir /home/node/js-re-scan
 WORKDIR /home/node/js-re-scan
 
-COPY package.json package-lock.json ./
+COPY --chown=node:node package.json package-lock.json ./
 RUN npm install \
 	--omit=dev \
 	--no-fund \
 	--no-update-notifier
 
-COPY ./ ./
+COPY --chown=node:node ./ ./
 
 ENTRYPOINT [ \
 	"npm", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ LABEL name="js-regex-security-scanner" \
 	version="0.2.0" \
 	license="Apache-2.0"
 
+ENV NODE_ENV=production
+
 USER node:node
 RUN mkdir /home/node/js-re-scan
 WORKDIR /home/node/js-re-scan


### PR DESCRIPTION
Relates to _nothing_

---

### Summary

Harden the scanner's Docker image based on the blog post [10 best practices to containerize Node.js web applications with Docker](https://snyk.io/blog/10-best-practices-to-containerize-nodejs-web-applications-with-docker/) by Snyk.