### PR TITLE
Add audit job to scan for secrets

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,12 +8,7 @@ permissions: read-all
 
 jobs:
   audit:
-    name: Audit (${{ matrix.ref }})
+    name: Audit
     uses: ericcornelissen/js-regex-security-scanner/.github/workflows/reusable-audit.yml@main
-    strategy:
-      matrix:
-        ref:
-          - main
-          - v0
     with:
-      ref: ${{ matrix.ref }}
+      refs: '["main", "v0"]'

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -53,3 +53,18 @@ jobs:
       - name: Audit production npm dependencies
         if: ${{ startsWith(inputs.ref, 'v') }}
         run: make audit-npm ARGS="--omit dev"
+  secrets:
+    name: Secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          fetch-depth: 0 # To allow for historic scans
+      - name: Scan for secrets
+        uses: gitleaks/gitleaks-action@5425999620c418539c61a8143f29e346d5f6cf08
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: false
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
+          GITLEAKS_ENABLE_SUMMARY: true

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -2,7 +2,8 @@ name: Audit
 on:
   workflow_call:
     inputs:
-      ref:
+      refs:
+        default: '[""]'
         required: false
         type: string
 
@@ -12,11 +13,15 @@ jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ref: ${{ fromJSON(inputs.refs) }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ matrix.ref }}
       - name: Download Syft and Grype
         run: make .bin/syft .bin/grype
       - name: Create SBOM
@@ -28,18 +33,22 @@ jobs:
         if: ${{ always() }}
         with:
           if-no-files-found: error
-          name: container-scan-${{ inputs.ref }}
+          name: container-scan-${{ matrix.ref }}
           path: |
             sbom.json
             vulns.json
   npm:
     name: npm
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ref: ${{ fromJSON(inputs.refs) }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ matrix.ref }}
       - name: Install Node.js
         uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b
         with:
@@ -48,10 +57,10 @@ jobs:
       - name: Install Node.js dependencies
         run: npm ci
       - name: Audit all npm dependencies
-        if: ${{ !startsWith(inputs.ref, 'v') }}
+        if: ${{ !startsWith(matrix.ref, 'v') }}
         run: make audit-npm
       - name: Audit production npm dependencies
-        if: ${{ startsWith(inputs.ref, 'v') }}
+        if: ${{ startsWith(matrix.ref, 'v') }}
         run: make audit-npm ARGS="--omit dev"
   secrets:
     name: Secrets


### PR DESCRIPTION
Relates to #30
Relates to #41

---

### Summary

Add a new job to the `reusable-audit.yml` workflow to scan for secrets. This job is powered by [Gitleaks]. The [gitleaks-action] supports both looking for secrets only in pushed commits as well as doing a historic scan (e.g.) `on: schedule`.

[gitleaks]: https://gitleaks.io/
[gitleaks-action]: https://github.com/gitleaks/gitleaks-action