### PR TITLE
Increase tests timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,9 @@ lint-md: node_modules/ ## Lint MarkDown files
 sbom: $(SBOM_FILE) ## Generate a Software Bill Of Materials (SBOM)
 
 test: build node_modules/ ## Run the tests
-	npm run ava -- tests/
+	npm run ava -- \
+		--timeout 20s \
+		tests/
 
 update-test-snapshots: build node_modules/ ## Update the test snapsthos
 	npm run ava -- tests/ --update-snapshots


### PR DESCRIPTION
Closes #42

---

### Summary

Increase the timeout for tests so that they don't time out, which happens particularly often in continuous integration jobs.

The tests for this project take a relatively long time to run because the start a Docker container and need to wait for it to terminate.