### PR TITLE
Create Make command to run all linters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,8 +112,13 @@ make build
 
 #### Linting
 
-This project uses linters to catch mistakes and enforce style. You can use the
-following commands to check your changes if applicable:
+This project uses linters to catch mistakes and enforce style. Run:
+
+```shell
+make lint
+```
+
+to run all linters or use the following commands to check specific file types:
 
 | File type        | Command            | Linter         |
 | :--------------- | :----------------- | :------------- |

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ help: ## Show this help message
 
 init: | $(BIN_DIR)/grype $(BIN_DIR)/syft node_modules/ ## Initialize the project dependencies
 
+lint: lint-docker lint-md ## Lint the project
+
 lint-docker: ## Lint the Dockerfile
 	@docker run -i --rm \
 		--mount "type=bind,source=$(ROOT_DIR)/.hadolint.yml,target=/.config/hadolint.yaml" \
@@ -61,7 +63,7 @@ test: build node_modules/ ## Run the tests
 update-test-snapshots: build node_modules/ ## Update the test snapsthos
 	npm run ava -- tests/ --update-snapshots
 
-.PHONY: default audit audit-docker audit-npm build clean help init lint-docker lint-md sbom test update-test-snapshots
+.PHONY: default audit audit-docker audit-npm build clean help init lint lint-docker lint-md sbom test update-test-snapshots
 
 $(SBOM_FILE): $(BIN_DIR)/syft $(TEMP_DIR)/dockerimage
 	./$(BIN_DIR)/syft $(IMAGE_NAME):latest


### PR DESCRIPTION
### Summary

To improve the dev experience, create a shortcut to run all linters. This avoids having to invoke all linters individually and possibly forgetting one.