### PR TITLE
Update the license validation configuration

### DIFF
--- a/.licensed.yml
+++ b/.licensed.yml
@@ -15,6 +15,7 @@ allowed:
   - isc
   - mit
   - openssl
+  - python-2.0
   - zlib
 
 reviewed:
@@ -26,13 +27,13 @@ reviewed:
     - doctrine # apache-2.0
     - esquery # bsd-3-clause
     - esrecurse # bsd-2-clause
-    - esutils # bsd-2-clause
     - estraverse # bsd-2-clause
+    - esutils # bsd-2-clause
     - fs.realpath # isc
     - glob # isc
     - ignore # mit
-    - lodash.merge # cc0
-    - type-fest # mit
+    - lodash.merge # mit
+    - type-fest # mit or cc0-1.0
     - uri-js # bsd-2-clause
 
 cache_path: .tmp/licensed


### PR DESCRIPTION
Relates to #32

---

### Summary

- Align the `allowed` licenses with the licenses of the manually `reviewed.npm` licenses.
- Order `reviewed.npm` packages alphabetically.
- Check the licenses for the version that are being used (before they were reviewed against the latest version of the package).
- Correct what license "lodash.merge" is available under.
- Correct the dual license "type-fest" is available under.