### PR TITLE
Bump Licensed from 3.7.3 to 3.8.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,7 @@ jobs:
         uses: jonabc/setup-licensed@23892537a4b9275324fe790ff1057eb1d00fddbd
         with:
           install-dir: ./.bin/
-          version: 3.7.3
+          version: 3.8.0
       - name: Install Node.js dependencies
         run: npm ci
       - name: Check Docker licenses

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -20,20 +20,20 @@ allowed:
 
 reviewed:
   npm:
-    - "@typescript-eslint/parser" # bsd-2-clause
-    - "@typescript-eslint/typescript-estree" # bsd-2-clause
-    - argparse # python-2.0
-    - color-convert # mit
-    - doctrine # apache-2.0
-    - esquery # bsd-3-clause
-    - esrecurse # bsd-2-clause
-    - estraverse # bsd-2-clause
-    - esutils # bsd-2-clause
-    - fs.realpath # isc
-    - glob # isc
-    - ignore # mit
-    - lodash.merge # mit
-    - type-fest # mit or cc0-1.0
-    - uri-js # bsd-2-clause
+    - "@typescript-eslint/parser@5.42.1" # bsd-2-clause
+    - "@typescript-eslint/typescript-estree@5.42.1" # bsd-2-clause
+    - argparse@2.0.1 # python-2.0
+    - color-convert@2.0.1 # mit
+    - doctrine@3.0.0 # apache-2.0
+    - esquery@1.4.0 # bsd-3-clause
+    - esrecurse@4.3.0 # bsd-2-clause
+    - estraverse@5.3.0 # bsd-2-clause
+    - esutils@2.0.3 # bsd-2-clause
+    - fs.realpath@1.0.0 # isc
+    - glob@7.2.3 # isc
+    - ignore@5.2.0 # mit
+    - lodash.merge@4.6.2 # mit
+    - type-fest@0.20.2 # mit or cc0-1.0
+    - uri-js@4.4.1 # bsd-2-clause
 
 cache_path: .tmp/licensed

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -36,4 +36,4 @@ reviewed:
     - type-fest@0.20.2 # mit or cc0-1.0
     - uri-js@4.4.1 # bsd-2-clause
 
-cache_path: .tmp/licensed
+cache_path: .tmp/licensed_cache

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,9 @@ license-check: license-check-docker license-check-npm ## Check the project depen
 license-check-docker: $(SBOM_FILE) ## Check Docker image dependency licenses
 	@node scripts/check-licenses.js
 
-license-check-npm: $(LICENSED_CACHE) ## Check npm dependency licenses
-	@./$(LICENSED) status
+license-check-npm: $(LICENSED) ## Check npm dependency licenses
+	@./$(LICENSED) status \
+		--data-source=configuration
 
 lint: lint-docker lint-md ## Lint the project
 
@@ -100,7 +101,7 @@ $(GRYPE):
 	@curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | \
 		sh -s -- -b ./$(BIN_DIR) $(GRYPE_VERSION)
 $(LICENSED):
-	@curl -sSL https://github.com/github/licensed/releases/download/3.7.3/licensed-3.7.3-linux-x64.tar.gz > \
+	@curl -sSL https://github.com/github/licensed/releases/download/3.8.0/licensed-3.8.0-linux-x64.tar.gz > \
 		$(TEMP_DIR)/licensed.tar.gz
 	@tar -xzf $(TEMP_DIR)/licensed.tar.gz --directory $(TEMP_DIR)
 	@rm -rf $(TEMP_DIR)/meta/ $(TEMP_DIR)/licensed.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,13 @@ IMAGE_NAME:=ericornelissen/js-re-scan
 
 GRYPE_VERSION:=v0.51.0
 HADOLINT_VERSION:=sha256:d355bd7df747a0f124f3b5e7b21e9dafd0cb19732a276f901f0fdee243ec1f3b # tag=2.9.2
+LICENSED_VERSION:=3.8.0
 SYFT_VERSION:=v0.59.0
 
 BIN_DIR:=.bin
-LICENSED_CACHE:=$(TEMP_DIR)/licensed
 ROOT_DIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 TEMP_DIR:=.tmp
+LICENSED_CACHE:=$(TEMP_DIR)/licensed_cache
 
 GRYPE=$(BIN_DIR)/grype
 LICENSED=$(BIN_DIR)/licensed
@@ -71,7 +72,7 @@ lint-md: $(NODE_MODULES) ## Lint MarkDown files
 
 notice-npm: $(LICENSED_CACHE) ## Create NOTICE for npm dependencies
 	@./$(LICENSED) notice
-	@mv $(TEMP_DIR)/licensed/NOTICE NOTICE-npm
+	@mv $(LICENSED_CACHE)/NOTICE NOTICE-npm
 
 sbom: $(SBOM_FILE) ## Generate a Software Bill Of Materials (SBOM)
 
@@ -101,7 +102,7 @@ $(GRYPE):
 	@curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | \
 		sh -s -- -b ./$(BIN_DIR) $(GRYPE_VERSION)
 $(LICENSED):
-	@curl -sSL https://github.com/github/licensed/releases/download/3.8.0/licensed-3.8.0-linux-x64.tar.gz > \
+	@curl -sSL https://github.com/github/licensed/releases/download/$(LICENSED_VERSION)/licensed-$(LICENSED_VERSION)-linux-x64.tar.gz > \
 		$(TEMP_DIR)/licensed.tar.gz
 	@tar -xzf $(TEMP_DIR)/licensed.tar.gz --directory $(TEMP_DIR)
 	@rm -rf $(TEMP_DIR)/meta/ $(TEMP_DIR)/licensed.tar.gz


### PR DESCRIPTION
Relates to  #32

---

### Summary

Update the version of Licensed used from 3.7.3 to 3.8.0. Use the new `--data-source` option on the "status" command to avoid having to create a cache of licenses. Unfortunately the "notice" command still needs the cache.