### PR TITLE
Bump Licensed from 3.8.0 to 3.9.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,8 @@ jobs:
   licenses:
     name: Licenses
     runs-on: ubuntu-latest
+    needs:
+      - build
     steps:
       - name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -37,7 +39,7 @@ jobs:
         uses: jonabc/setup-licensed@23892537a4b9275324fe790ff1057eb1d00fddbd # v1.1.3
         with:
           install-dir: ./.bin/
-          version: 3.8.0
+          version: 3.9.0
       - name: Install Node.js dependencies
         run: npm ci
       - name: Check Docker licenses

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -36,4 +36,4 @@ reviewed:
     - type-fest@0.20.2 # mit or cc0-1.0
     - uri-js@4.4.1 # bsd-2-clause
 
-cache_path: .tmp/licensed_cache
+cache_path: .tmp/

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ SYFT_VERSION:=v0.59.0
 BIN_DIR:=.bin
 ROOT_DIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 TEMP_DIR:=.tmp
-LICENSED_CACHE:=$(TEMP_DIR)/licensed_cache
 
 GRYPE=$(BIN_DIR)/grype
 LICENSED=$(BIN_DIR)/licensed
@@ -53,7 +52,7 @@ license-check: license-check-docker license-check-npm ## Check the project depen
 license-check-docker: $(SBOM_FILE) ## Check Docker image dependency licenses
 	@node scripts/check-licenses.js
 
-license-check-npm: $(LICENSED) ## Check npm dependency licenses
+license-check-npm: $(LICENSED) $(NODE_MODULES) ## Check npm dependency licenses
 	@./$(LICENSED) status \
 		--data-source=configuration
 
@@ -73,9 +72,9 @@ lint-md: $(NODE_MODULES) ## Lint MarkDown files
 		--ignore testdata/ \
 		.
 
-notice-npm: $(LICENSED) ## Create NOTICE for npm dependencies
+notice-npm: $(LICENSED) $(NODE_MODULES) $(TEMP_DIR) ## Create NOTICE for npm dependencies
 	@./$(LICENSED) notice --computed
-	@mv $(LICENSED_CACHE)/NOTICE $(NOTICE_FILE_NPM)
+	@mv $(TEMP_DIR)/NOTICE $(NOTICE_FILE_NPM)
 
 sbom: $(SBOM_FILE) ## Generate a Software Bill Of Materials (SBOM)
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ IMAGE_NAME:=ericornelissen/js-re-scan
 
 GRYPE_VERSION:=v0.51.0
 HADOLINT_VERSION:=sha256:9259e253a4e299b50c92006149dd3a171c7ea3c5bd36f060022b5d2c1ff0fbbe # tag=2.12.0
-LICENSED_VERSION:=3.8.0
+LICENSED_VERSION:=3.9.0
 SYFT_VERSION:=v0.59.0
 
 BIN_DIR:=.bin
@@ -73,8 +73,8 @@ lint-md: $(NODE_MODULES) ## Lint MarkDown files
 		--ignore testdata/ \
 		.
 
-notice-npm: $(LICENSED_CACHE) ## Create NOTICE for npm dependencies
-	@./$(LICENSED) notice
+notice-npm: $(LICENSED) ## Create NOTICE for npm dependencies
+	@./$(LICENSED) notice --computed
 	@mv $(LICENSED_CACHE)/NOTICE $(NOTICE_FILE_NPM)
 
 sbom: $(SBOM_FILE) ## Generate a Software Bill Of Materials (SBOM)
@@ -120,5 +120,3 @@ $(TEMP_DIR):
 $(TEMP_DIR)/dockerimage: $(TEMP_DIR) .dockerignore .eslintrc.yml Dockerfile package*.json
 	@docker build --tag $(IMAGE_NAME) .
 	@touch $(TEMP_DIR)/dockerimage
-$(LICENSED_CACHE): $(LICENSED) $(NODE_MODULES) $(TEMP_DIR)
-	@./$(LICENSED) cache


### PR DESCRIPTION
Relates to #36, #90

---

### Summary

Update the version of Licensed used from 3.7.3 to 3.8.0. Use the new `--computed` option on the "notice" command to avoid having to create.