### PR TITLE
Reconfigure yamllint's `truthy` rule

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,5 +1,5 @@
 name: Check
-on: # yamllint disable-line rule:truthy
+on:
   pull_request: ~
   push:
     branches:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,5 @@
 name: Nightly
-on: # yamllint disable-line rule:truthy
+on:
   schedule:
     - cron: 0 3 * * *
   workflow_dispatch: ~

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Release
-on: # yamllint disable-line rule:truthy
+on:
   push:
     tags:
       - v*

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -1,5 +1,5 @@
 name: Audit
-on: # yamllint disable-line rule:truthy
+on:
   workflow_call:
     inputs:
       refs:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -79,4 +79,4 @@ rules:
     allowed-values:
       - "true"
       - "false"
-    check-keys: true
+    check-keys: false


### PR DESCRIPTION
Relates to #70, #109 

---

### Summary

Update the configuration of yamllint's `truthy` rule to NOT check keys for truthy values.