### PR TITLE
Pin all runner images in GitHub Actions workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
       - build
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
@@ -24,7 +24,7 @@ jobs:
         run: make build
   licenses:
     name: Licenses
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - build
     steps:
@@ -59,7 +59,7 @@ jobs:
             NOTICE-npm
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
@@ -90,7 +90,7 @@ jobs:
         run: make lint-ci
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - build
     steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
       - build
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
@@ -24,7 +24,7 @@ jobs:
         run: make build
   licenses:
     name: Licenses
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - build
     steps:
@@ -59,7 +59,7 @@ jobs:
             NOTICE-npm
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
@@ -90,7 +90,7 @@ jobs:
         run: make lint-ci
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - build
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   branch:
     name: Branch
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write # To push a branch
     needs:
@@ -33,7 +33,7 @@ jobs:
         run: git push origin HEAD:${{ steps.version.outputs.result }}
   docker-hub:
     name: Docker Hub
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - validate
     steps:
@@ -63,7 +63,7 @@ jobs:
             ericornelissen/js-re-scan:${{ steps.version.outputs.result }}
   validate:
     name: Validate
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   branch:
     name: Branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: write # To push a branch
     needs:
@@ -33,7 +33,7 @@ jobs:
         run: git push origin HEAD:${{ steps.version.outputs.result }}
   docker-hub:
     name: Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - validate
     steps:
@@ -63,7 +63,7 @@ jobs:
             ericornelissen/js-re-scan:${{ steps.version.outputs.result }}
   validate:
     name: Validate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   docker:
     name: Docker
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +40,7 @@ jobs:
             vulns.json
   npm:
     name: npm
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -65,7 +65,7 @@ jobs:
         run: make audit-npm ARGS="--omit dev"
   secrets:
     name: Secrets
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   docker:
     name: Docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +40,7 @@ jobs:
             vulns.json
   npm:
     name: npm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -65,7 +65,7 @@ jobs:
         run: make audit-npm ARGS="--omit dev"
   secrets:
     name: Secrets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0


### PR DESCRIPTION
### Summary

Update all GitHub Actions workflows to use a specific runner image rather than "-latest" for all jobs.