### PR TITLE
Fix cosign usage in "Release / Docker Hub" job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,8 @@ jobs:
             return tag
       - name: Install cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2.8.1
+        with:
+          cosign-release: v1.13.1
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
@@ -67,6 +69,8 @@ jobs:
             ericornelissen/js-re-scan:latest,
             ericornelissen/js-re-scan:${{ steps.version.outputs.result }}
       - name: Sign container image (experimental)
+        env:
+          COSIGN_EXPERIMENTAL: 1
         run: |
           cosign sign \
             -a "repo=${{ github.repository }}" \


### PR DESCRIPTION
Relates to #125, #127

## Summary

Update the "Release / Docker Hub" job to correct the usage of [cosign] for [keyless signing] of the Docker image published to Docker Hub.

[cosign]: https://github.com/sigstore/cosign
[keyless signing]: https://github.com/sigstore/cosign/blob/44d58de/KEYLESS.md