### PR TITLE
Refine "Check / Lint" job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -62,18 +62,18 @@ jobs:
         run: |
           npm ci
           go install github.com/rhysd/actionlint/cmd/actionlint@v1.6.22
+      - name: Lint CI
+        if: ${{ failure() || success() }}
+        run: make lint-ci
       - name: Lint Dockerfile
-        if:  ${{ failure() || success() }}
+        if: ${{ failure() || success() }}
         run: make lint-docker
       - name: Lint MarkDown
-        if:  ${{ failure() || success() }}
+        if: ${{ failure() || success() }}
         run: make lint-md
       - name: Lint YAML
-        if:  ${{ failure() || success() }}
+        if: ${{ failure() || success() }}
         run: make lint-yml
-      - name: Lint workflows
-        if:  ${{ failure() || success() }}
-        run: make lint-ci
   test:
     name: Test
     runs-on: ubuntu-22.04

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,16 +63,16 @@ jobs:
           npm ci
           go install github.com/rhysd/actionlint/cmd/actionlint@v1.6.22
       - name: Lint Dockerfile
-        if: ${{ always() }}
+        if:  ${{ failure() || success() }}
         run: make lint-docker
       - name: Lint MarkDown
-        if: ${{ always() }}
+        if:  ${{ failure() || success() }}
         run: make lint-md
       - name: Lint YAML
-        if: ${{ always() }}
+        if:  ${{ failure() || success() }}
         run: make lint-yml
       - name: Lint workflows
-        if: ${{ always() }}
+        if:  ${{ failure() || success() }}
         run: make lint-ci
   test:
     name: Test


### PR DESCRIPTION
## Summary

Rework the "Check / Lint" CI job to run all linters only if the job setup succeeded instead of `${{ always() }}`, regardless of setup failures.