### PR TITLE
Track tool versions in `.tool-versions`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,14 +54,10 @@ jobs:
         with:
           node-version: 18
           cache: npm
-      - name: Install Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
-        with:
-          go-version: 1.17
+      - name: Install tooling
+        uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Install Node.js dependencies
-        run: |
-          npm ci
-          go install github.com/rhysd/actionlint/cmd/actionlint@v1.6.22
+        run: npm ci
       - name: Lint CI
         if: ${{ failure() || success() }}
         run: make lint-ci

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,4 @@
+# Check out asdf at: https://asdf-vm.com/
+
+actionlint 1.6.22
+shellcheck 0.9.0


### PR DESCRIPTION
Relates to #36

## Summary

Create a `.tool-versions` file with a select few tools and their corresponding version. The file name and  format is based on [asdf] but is also human-readable so suitable for simple reference as well. Having this available should help with reproducibility and help contributors figure out how to get the correct outputs for each of these tools.

[asdf]: https://asdf-vm.com/