### PR TITLE
Pin hadolint image to tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMAGE_NAME:=ericornelissen/js-re-scan
 
 GRYPE_VERSION:=v0.54.0
-HADOLINT_VERSION:=sha256:9259e253a4e299b50c92006149dd3a171c7ea3c5bd36f060022b5d2c1ff0fbbe # tag=2.12.0
+HADOLINT_VERSION:=v2.12.0
 SYFT_VERSION:=v0.63.0
 
 BIN_DIR:=.bin
@@ -62,7 +62,7 @@ lint-ci: ## Lint Continuous Integration configuration files
 lint-docker: ## Lint the Dockerfile
 	@docker run -i --rm \
 		--mount "type=bind,source=$(ROOT_DIR)/.hadolint.yml,target=/.config/hadolint.yaml" \
-		hadolint/hadolint@$(HADOLINT_VERSION) \
+		hadolint/hadolint:$(HADOLINT_VERSION) \
 		< Dockerfile
 
 lint-md: $(NODE_MODULES) ## Lint MarkDown files


### PR DESCRIPTION
Relates to #36, #79

## Summary

Update the `HADOLINT_VERSION` to pin the image to a tag instead of SHA. While the latter provides better security & reproducibility guarantees, pinning to the SHA ties the version to an architecture. Pinning to a tag avoids this last problem, while still providing reasonable guarantees for reproducibility.