### PR TITLE
Update "Check / Licenses" job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,10 +38,10 @@ jobs:
       - name: Install Node.js dependencies
         run: npm clean-install
       - name: Check Docker licenses
-        if: ${{ always() }}
+        if: ${{ failure() || success() }}
         run: make license-check-docker
       - name: Check npm licenses
-        if: ${{ always() }}
+        if: ${{ failure() || success() }}
         run: make license-check-npm
   lint:
     name: Lint


### PR DESCRIPTION
Relates to #135

## Summary

Rework the "Check / Licenses" CI job to run all license checks only if the job failed or succeeded, not when it was cancelled or otherwise stopped.