### PR TITLE
Create `make verify` command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,5 @@ jobs:
           node-version: 18
       - name: Install Node.js dependencies
         run: npm clean-install
-      - name: Build
-        run: make build
-      - name: Test
-        run: make test
+      - name: Verify project validity
+        run: make verify

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,9 @@ update-test-snapshots: build $(NODE_MODULES) ## Update the test snapsthos
 		--update-snapshots \
 		tests/
 
-.PHONY: default audit audit-docker audit-npm build clean help init license-check license-check-docker license-check-npm lint lint-ci lint-docker lint-md lint-yml sbom test update-test-snapshots
+verify: build license-check lint test ## Verify project is in a good state
+
+.PHONY: default audit audit-docker audit-npm build clean help init license-check license-check-docker license-check-npm lint lint-ci lint-docker lint-md lint-yml sbom test update-test-snapshots verify
 
 $(SBOM_FILE): $(SYFT) $(TEMP_DIR)/dockerimages/latest
 	@./$(SYFT) $(IMAGE_NAME):latest


### PR DESCRIPTION
## Summary

Update the `Makefile` to include a phony target called 'verify' that can be used to _"Verify project is in a good state"_. This is a convenience target/command to quickly run tests and other checks.

Use this command to verify the state of the project prior to releasing a new version in the release automation.