### PR TITLE
Update "Audit / Docker" job

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -31,7 +31,7 @@ jobs:
         run: make audit-docker
       - name: Upload SBOM and vulnerability scan
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
-        if: ${{ always() }}
+        if: ${{ failure() || success() }}
         with:
           if-no-files-found: error
           name: container-scan-${{ matrix.ref }}


### PR DESCRIPTION
Relates to #135,  #139

## Summary

Rework the "Audit / Docker" CI job to upload artifacts only if the job failed or succeedded, not when it was cancelled or otherwise stopped.