### PR TITLE
Avoid unnecessary job setup in continuous integration

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,8 +35,6 @@ jobs:
         with:
           node-version: 18
           cache: npm
-      - name: Install Node.js dependencies
-        run: npm clean-install
       - name: Check Docker licenses
         if: ${{ failure() || success() }}
         run: make license-check-docker
@@ -56,8 +54,6 @@ jobs:
           cache: npm
       - name: Install tooling
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
-      - name: Install Node.js dependencies
-        run: npm clean-install
       - name: Lint CI
         if: ${{ failure() || success() }}
         run: make lint-ci
@@ -85,7 +81,5 @@ jobs:
         with:
           node-version: 18
           cache: npm
-      - name: Install Node.js dependencies
-        run: npm clean-install
       - name: Test
         run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,6 @@ jobs:
         with:
           cache: npm
           node-version: 18
-      - name: Install Node.js dependencies
-        run: npm clean-install
       - name: Build
         run: make build
       - name: Test

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -23,11 +23,7 @@ jobs:
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           ref: ${{ matrix.ref }}
-      - name: Download Syft and Grype
-        run: make .bin/syft .bin/grype
-      - name: Create SBOM
-        run: make sbom
-      - name: Scan SBOM
+      - name: Audit dependencies in Docker image
         run: make audit-docker
       - name: Upload SBOM and vulnerability scan
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
@@ -55,8 +51,6 @@ jobs:
         with:
           node-version: 18
           cache: npm
-      - name: Install Node.js dependencies
-        run: npm clean-install
       - name: Audit all npm dependencies
         if: ${{ !startsWith(matrix.ref, 'v') }}
         run: make audit-npm


### PR DESCRIPTION
Relates to #136, #140

## Summary

Update all continuous integration workflows to avoid doing any setup explicit when it's not necessary. This simplifies the workflows, avoids unneeded setups, and reduces maintenance.