### PR TITLE
Fix verification in "Release / Validate" job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,5 +90,7 @@ jobs:
         with:
           cache: npm
           node-version: 18
+      - name: Install tooling
+        uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Verify project validity
         run: make verify


### PR DESCRIPTION
Relates to #140, #142, https://github.com/ericcornelissen/js-regex-security-scanner/pull/145#issuecomment-1369714185

## Summary

Update the "Release / Validate" job to install tooling using [`asdf-vm/actions`]. This is necessary as some of the commands ran by `make verify` require the tools installed through `asdf`.

[`asdf-vm/actions`]: https://github.com/asdf-vm/actions