### PR TITLE
Track Syft & Grype versions in `.tool-versions`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,6 +35,8 @@ jobs:
         with:
           node-version: 18
           cache: npm
+      - name: Install tooling
+        uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Check Docker licenses
         if: ${{ failure() || success() }}
         run: make license-check-docker

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           ref: ${{ matrix.ref }}
+      - name: Install tooling
+        uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Audit dependencies in Docker image
         run: make audit-docker
       - name: Upload SBOM and vulnerability scan

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,6 @@
 # Check out asdf at: https://asdf-vm.com/
 
 actionlint 1.6.22
+grype 0.54.0
 shellcheck 0.9.0
+syft 0.63.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,10 @@ To be able to contribute you need at least the following:
 - [Make];
 - [Node.js] v18.0.0 or higher and [npm] v8.1.2 or higher;
 - (Recommended) a code editor with [EditorConfig] support;
-- (Optional) [actionlint] and [ShellCheck];
+- (Optional) [actionlint] (see `.tool-versions` for preferred version);
+- (Optional) [Grype] (see `.tool-versions` for preferred version);
+- (Optional) [ShellCheck] (see `.tool-versions` for preferred version);
+- (Optional) [Syft] (see `.tool-versions` for preferred version);
 - (Optional) [yamllint];
 
 ### Workflow


### PR DESCRIPTION
Relates to #36

## Summary

Move the recorded versions for both [Grype] and [Syft] from the `Makefile` to the `.tool-versions` file. This helps consolidate tooling version information in a single place and allows for installing the preferred versions of these tools using [asdf].

[grype]: https://github.com/anchore/grype
[syft]: https://github.com/anchore/syft
[asdf]: https://asdf-vm.com/