### PR TITLE
Track yamllint versions in `.tool-versions`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,6 +35,11 @@ jobs:
         with:
           node-version: 18
           cache: npm
+      - name: Install asdf
+        uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
+      - name: Add plugins
+        run: |
+         asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
       - name: Install tooling
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Check Docker licenses
@@ -54,6 +59,11 @@ jobs:
         with:
           node-version: 18
           cache: npm
+      - name: Install asdf
+        uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
+      - name: Add plugins
+        run: |
+         asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
       - name: Install tooling
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Lint CI

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,6 +31,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Install asdf
+        uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
+      - name: Add plugins
+        run: |
+         asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
       - name: Install tooling
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Create token to create Pull Request

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,6 +27,7 @@ jobs:
           - grype
           - shellcheck
           - syft
+          - yamllint
     steps:
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,11 @@ jobs:
         with:
           cache: npm
           node-version: 18
+      - name: Install asdf
+        uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
+      - name: Add plugins
+        run: |
+         asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
       - name: Install tooling
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Verify project validity

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -23,6 +23,11 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           ref: ${{ matrix.ref }}
+      - name: Install asdf
+        uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
+      - name: Add plugins
+        run: |
+         asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
       - name: Install tooling
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Audit dependencies in Docker image

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,3 +4,4 @@ actionlint 1.6.22
 grype 0.54.0
 shellcheck 0.9.0
 syft 0.63.0
+yamllint 1.28.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ To be able to contribute you need at least the following:
 - (Optional) [Grype] (see `.tool-versions` for preferred version);
 - (Optional) [ShellCheck] (see `.tool-versions` for preferred version);
 - (Optional) [Syft] (see `.tool-versions` for preferred version);
-- (Optional) [yamllint];
+- (Optional) [yamllint] (see `.tool-versions` for preferred version);
 
 ### Workflow
 


### PR DESCRIPTION
Relates to #36, #109

## Summary

Add the used version of [yamllint] to the `.tool-versions` file. This helps consolidate tooling version information in a single place and allows for installing the preferred versions of yamllint using [asdf].

[yamllint]: https://github.com/adrienverge/yamllint
[asdf]: https://asdf-vm.com/