### PR TITLE
Disable auditing when building the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ WORKDIR /home/node/js-re-scan
 COPY --chown=node:node package.json package-lock.json ./
 RUN npm install \
 	--omit=dev \
+	--no-audit \
 	--no-fund \
 	--no-update-notifier
 


### PR DESCRIPTION
## Summary

Update the Dockerfile to disable auditing of dependencies when installing dependencies during `docker build`. This project has other, explicit, ways of keeping an eye on known vulnerabilities in third-party components.