### PR TITLE
Track hadolint in `.tool-versions`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,6 +25,7 @@ jobs:
         tool:
           - actionlint
           - grype
+          - hadolint
           - shellcheck
           - syft
           - yamllint

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,6 +2,7 @@
 
 actionlint 1.6.22
 grype 0.55.0
+hadolint 2.12.0
 shellcheck 0.9.0
 syft 0.66.1
 yamllint 1.29.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,7 @@ To be able to contribute you need at least the following:
 - (Recommended) a code editor with [EditorConfig] support;
 - (Optional) [actionlint] (see `.tool-versions` for preferred version);
 - (Optional) [Grype] (see `.tool-versions` for preferred version);
+- (Optional) [hadolint] (see `.tool-versions` for preferred version);
 - (Optional) [ShellCheck] (see `.tool-versions` for preferred version);
 - (Optional) [Syft] (see `.tool-versions` for preferred version);
 - (Optional) [yamllint] (see `.tool-versions` for preferred version);

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 IMAGE_NAME:=ericornelissen/js-re-scan
 
-HADOLINT_VERSION:=v2.12.0
-
 BIN_DIR:=.bin
 NODE_MODULES=node_modules
 ROOT_DIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
@@ -59,11 +57,9 @@ lint: lint-ci lint-docker lint-md lint-yml ## Lint the project
 lint-ci: $(ASDF) ## Lint Continuous Integration configuration files
 	@actionlint
 
-lint-docker: ## Lint the Dockerfile
-	@docker run -i --rm \
-		--mount "type=bind,source=$(ROOT_DIR)/.hadolint.yml,target=/.config/hadolint.yaml" \
-		hadolint/hadolint:$(HADOLINT_VERSION) \
-		< Dockerfile
+lint-docker: $(ASDF) ## Lint the Dockerfile
+	@hadolint \
+		Dockerfile
 
 lint-md: $(NODE_MODULES) ## Lint MarkDown files
 	@npx markdownlint \


### PR DESCRIPTION
Relates to #36, #67

## Summary

Track the version of [hadolint] used in the `.tool-versions` file.

[hadolint]: https://github.com/hadolint/hadolint