### PR TITLE
Automate release process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Publish
 on:
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      update_type:
+        description: Update type
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions: read-all
+
+jobs:
+  initiate:
+    name: Initiate
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write # To push a commit
+      pull-requests: write # To open a Pull Request
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Install Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: 18
+          cache: npm
+      - name: Create token to create Pull Request
+        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c # v1.7.0
+        id: pull_request_token
+        with:
+          app_id: ${{ secrets.RELEASE_APP_ID }}
+          private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+      - name: Bump version
+        run: node scripts/bump-version.js '${{ github.event.inputs.update_type }}'
+      - name: Update the changelog
+        run: node scripts/bump-changelog.js
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@d7db273d6c7206ba99224e659c982ae34a1025e3 # v4.2.1
+        with:
+          token: ${{ steps.pull_request_token.outputs.token }}
+          title: New ${{ github.event.inputs.update_type }} release for v0
+          body: |
+            _This Pull Request was created automatically_
+
+            ---
+
+            ### Merge checklist
+
+            - [ ] All continuous integration checks passed.
+            - [ ] The version number is updated in `Dockerfile`.
+            - [ ] The new release is added to `CHANGELOG.md` with the correct version number and date.
+            - [ ] The new version number is in accordance with the [Semantic Versioning] rules.
+            - [ ] There are no other changes in the Pull Request.
+
+            ### Post-merge
+
+            Pull the `main` branch, create a git tag for the new release and push it.
+
+            [semantic versioning]: https://semver.org/spec/v2.0.0.html
+          branch: release-${{ github.event.inputs.update_type }}
+          branch-suffix: random
+          commit-message: Version bump

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,22 @@
 # Release Guidelines
 
-If you need to release a new version of _JavaScript Regex Security Scanner_,
+If you need to release a new version of the _JavaScript Regex Security Scanner_,
 follow the guidelines found in this document.
 
-Follow these steps to release a new version (using `v0.1.2` as an example):
+## Automated Releases (Preferred)
+
+To release a new version follow these steps:
+
+1. [Manually trigger] the [release workflow] from the `main` branch; Use an
+   update type in accordance with [Semantic Versioning]. This will create a Pull
+   Request that start the release process.
+1. Follow the instructions in the description of the created Pull Request.
+
+## Manual Releases (Discouraged)
+
+If it's not possible to use automated releases, or if something goes wrong with
+the automatic release process, follow these steps to release a new version
+(using `v0.1.2` as an example):
 
 1. Make sure that your local copy of the repository is up-to-date, sync:
 
@@ -115,3 +128,6 @@ Follow these steps to release a new version (using `v0.1.2` as an example):
 
 [docker]: https://www.docker.com/
 [git tag]: https://git-scm.com/book/en/v2/Git-Basics-Tagging
+[manually trigger]: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+[release workflow]: ./.github/workflows/release.yml
+[semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,13 @@ Follow these steps to release a new version (using `v0.1.2` as an example):
    git clone git@github.com:ericcornelissen/js-regex-security-scanner.git
    ```
 
-1. Manually update the `version` label in the `Dockerfile`.
+1. Update the `version` label in the `Dockerfile` using:
+
+   ```shell
+   node script/bump-version.js [patch|minor|major]
+   ```
+
+   If that fails, manually update the `version` label in the `Dockerfile`:
 
    ```diff
    -  version="0.1.1" \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,7 +21,7 @@ Follow these steps to release a new version (using `v0.1.2` as an example):
 1. Update the `version` label in the `Dockerfile` using:
 
    ```shell
-   node script/bump-version.js [patch|minor|major]
+   node scripts/bump-version.js [patch|minor|major]
    ```
 
    If that fails, manually update the `version` label in the `Dockerfile`:
@@ -31,7 +31,14 @@ Follow these steps to release a new version (using `v0.1.2` as an example):
    +  version="0.1.2" \
    ```
 
-1. Manually add the following text after the `## [Unreleased]` line:
+1. Update the changelog:
+
+   ```shell
+   node scripts/bump-changelog.js
+   ```
+
+   If that fails, manually add the following text after the `## [Unreleased]`
+   line:
 
    ```markdown
    - _No changes yet_

--- a/scripts/bump-changelog.js
+++ b/scripts/bump-changelog.js
@@ -1,0 +1,80 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as url from "node:url";
+
+// ---------
+// Constants
+// ---------
+
+const STR_UNRELEASED = "## [Unreleased]";
+const STR_NO_CHANGES = "- _No changes yet_";
+
+const projectRoot = path.resolve(
+	path.dirname(
+		url.fileURLToPath(
+			new URL(import.meta.url),
+		),
+	),
+	"..",
+);
+
+// -------------
+// Paths & Files
+// -------------
+
+const changelogFilePath = path.resolve(
+	projectRoot,
+	"CHANGELOG.md",
+);
+const dockerFilePath = path.resolve(
+	projectRoot,
+	"Dockerfile",
+);
+
+const dockerFileRaw = fs.readFileSync(dockerFilePath).toString();
+const changelogRaw = fs.readFileSync(changelogFilePath).toString();
+
+// ---------------
+// Current version
+// ---------------
+
+const versionLabel = dockerFileRaw.split(/\n/)
+	.map(line => line.trim())
+	.find(line => line.startsWith("version="));
+const version = versionLabel.split("\"")[1];
+
+// ----------
+// Validation
+// ----------
+
+if (changelogRaw.includes(`## [${version}]`)) {
+	throw new Error(`${version} already in CHANGELOG`);
+}
+
+const unreleasedTitleIndex = changelogRaw.indexOf(STR_UNRELEASED);
+if (unreleasedTitleIndex === -1) {
+	throw new Error("The CHANGELOG is invalid");
+}
+
+if (changelogRaw.includes(STR_NO_CHANGES)) {
+	throw new Error("No changes to release in the CHANGELOG");
+}
+
+// -----------------
+// Changelog updates
+// -----------------
+
+const date = new Date();
+const year = date.getFullYear();
+const _month = date.getMonth() + 1;
+const month = _month < 10 ? `0${_month}` : _month;
+const _day = date.getDate();
+const day = _day < 10 ? `0${_day}` : _day;
+
+const newChangelog =
+	changelogRaw.slice(0, unreleasedTitleIndex + STR_UNRELEASED.length) +
+	`\n\n${STR_NO_CHANGES}` +
+	`\n\n## [${version}] - ${year}-${month}-${day}` +
+	changelogRaw.slice(unreleasedTitleIndex + STR_UNRELEASED.length);
+
+fs.writeFileSync(changelogFilePath, newChangelog);

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,0 +1,50 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as process from "node:process";
+import * as url from "node:url";
+
+const projectRoot = path.resolve(
+	path.dirname(
+		url.fileURLToPath(
+			new URL(import.meta.url),
+		),
+	),
+	"..",
+);
+const dockerFilePath = path.resolve(
+	projectRoot,
+	"Dockerfile",
+);
+
+const dockerFileRaw = fs.readFileSync(dockerFilePath).toString();
+
+const versionLabel = dockerFileRaw.split(/\n/)
+	.map(line => line.trim())
+	.find(line => line.startsWith("version="));
+const version = versionLabel.split("\"")[1];
+
+const versionTuple = version.split(".");
+switch (process.argv[2]) {
+	case "patch":
+		versionTuple[2] = parseInt(versionTuple[2], 10) + 1;
+		break;
+	case "minor":
+		versionTuple[1] = parseInt(versionTuple[1], 10) + 1;
+		versionTuple[2] = 0;
+		break;
+	case "major":
+		versionTuple[0] = parseInt(versionTuple[0], 10) + 1;
+		versionTuple[1] = 0;
+		versionTuple[2] = 0;
+		break;
+	default:
+		console.log(`unknown argument '${process.argv[2]}'`);
+		console.log("must be one of 'patch', 'minor', 'major'");
+		break;
+}
+
+const newVersion = versionTuple.join(".");
+fs.writeFileSync(
+	dockerFilePath,
+	dockerFileRaw.replace(versionLabel, `version="${newVersion}" \\`),
+);


### PR DESCRIPTION
Relates to #46

## Summary

Automate steps of the release process with the goal of completely automating steps 2 to 5 of the [Release Guidelines](https://github.com/ericcornelissen/js-regex-security-scanner/blob/0f35947e21fc8e54d8a9b28c501eb2780d188fdf/RELEASE.md).