### PR TITLE
Update tooling setup in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,11 +35,6 @@ jobs:
         with:
           node-version: 18
           cache: npm
-      - name: Install asdf
-        uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
-      - name: Add plugins
-        run: |
-         asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
       - name: Install tooling
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Check Docker licenses
@@ -59,11 +54,6 @@ jobs:
         with:
           node-version: 18
           cache: npm
-      - name: Install asdf
-        uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
-      - name: Add plugins
-        run: |
-         asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
       - name: Install tooling
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Lint CI

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,11 +32,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - name: Install asdf
-        uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
-      - name: Add plugins
-        run: |
-         asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
       - name: Install tooling
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Create token to create Pull Request

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,11 +90,6 @@ jobs:
         with:
           cache: npm
           node-version: 18
-      - name: Install asdf
-        uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
-      - name: Add plugins
-        run: |
-         asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
       - name: Install tooling
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Verify project validity

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -23,11 +23,6 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           ref: ${{ matrix.ref }}
-      - name: Install asdf
-        uses: asdf-vm/actions/setup@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
-      - name: Add plugins
-        run: |
-         asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
       - name: Install tooling
         uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
       - name: Audit dependencies in Docker image


### PR DESCRIPTION
Relates to #109 and #163

## Summary

The plugin is now available without explicitly adding it. So, remove the explicit setup from the continuous integration workflows.