### PR TITLE
Update base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ Versioning].
 
 ## [Unreleased]
 
+- (`3ceecf8`) Bump Alpine from `3.15` to `3.17`.
 - (`2174ef9`) Bump ESLint from `8.32.0` to `8.33.0`.
 - (`88c2751`) Bump ESLint from `8.33.0` to `8.34.0`.
+- (`3ceecf8`) Bump Node.js runtime from `18.12.1` to `18.14.1`.
 - (`cc1f6c5`) Bump `@typescript-eslint/parser` from `5.48.2` to `5.49.0`.
 
 ## [0.4.0] - 2023-01-17

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:18.12.1-alpine3.15
+FROM node:18.14.1-alpine3.17
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
## Summary

Update the scanner image's base image from _Node.js v18.12.1 on Alpine 3.15_ to _Node.js v18.14.1 on Alpine 3.17_.

This is the latest available Node.js v18.x.x image at the time of writing. This upgrade resolves a couple of vulnerabilities present in packages present in the old base image, namely:

- CVE-2022-4304
- CVE-2022-4450
- CVE-2023-0215
- CVE-2023-0286

### Security assessment

Given all these CVEs are in `openssl/libssl` and this scanner does not use the network at runtime we assume this scanner is not affected by these vulnerabilities.

In theory these vulnerabilities could be exploited at build time in [stage 5](https://github.com/ericcornelissen/js-regex-security-scanner/blob/e8aca1520a73ab1b788701ac9076de9b350af719/Dockerfile#L29-L33) but 1) this could not realistically have happened when the image was build and published to Docker hub, and 2) this is largely mitigated by the fact that everything that's installed in that step is checksum verified (through [`package-lock.json`](https://github.com/ericcornelissen/js-regex-security-scanner/blob/e8aca1520a73ab1b788701ac9076de9b350af719/package-lock.json)).