### PR TITLE
Track cosign version in `.tool-versions`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         tool:
           - actionlint
+          - cosign
           - grype
           - hadolint
           - shellcheck
@@ -39,6 +40,7 @@ jobs:
             api.github.com:443
             files.pythonhosted.org:443
             github.com:443
+            gitlab.com:443
             objects.githubusercontent.com:443
             pypi.org:443
       - name: Checkout repository
@@ -73,7 +75,7 @@ jobs:
             ---
 
             Bump ${{ matrix.tool }} to v${{ steps.version.outputs.latest }}
-          branch: asdf-${{ matrix.tool }}-${{ steps.version.outputs.latest }}
+          branch: tooling-${{ matrix.tool }}-${{ steps.version.outputs.latest }}
           labels: dependencies
           commit-message: Update ${{ matrix.tool }} to ${{ steps.version.outputs.latest }}
           add-paths: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,10 +61,15 @@ jobs:
             const ref = context.ref
             const tag = ref.replace(/^refs\/tags\//, "")
             return tag
+      - name: Get cosign version
+        id: versions
+        run: |
+          COSIGN_VERSION="$(grep cosign < .tool-versions | awk '{print $2}')"
+          echo "cosign=$COSIGN_VERSION" >> "$GITHUB_OUTPUT"
       - name: Install cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2.8.1
         with:
-          cosign-release: v1.13.1
+          cosign-release: v${{ steps.versions.outputs.cosign }}
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -3,6 +3,7 @@
 # - rtx: https://github.com/jdxcode/rtx
 
 actionlint 1.6.23
+cosign 1.13.1
 grype 0.57.1
 hadolint 2.12.0
 shellcheck 0.9.0


### PR DESCRIPTION
Relates to #125, #137

## Summary

Add cosign to the .tool-versions file to track it alongside other tools. Most notably this allows it to be incorporated in the nightly tooling update workflow.