### PR TITLE
Update copyright year

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022 Eric Cornelissen
+# Copyright 2023 Eric Cornelissen
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

Update the copyright year for the source code. Triggered, in part, by [`curl`s recent related decision](https://daniel.haxx.se/blog/2023/01/08/copyright-without-years/). I re-reviewed the usage of license texts in this project and this is the only place with a year.