### PR TITLE
Update continuous deployment pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,7 +86,7 @@ jobs:
             ericornelissen/js-re-scan:${{ steps.version.outputs.result }}
       - name: Sign container image (experimental)
         run: |
-          cosign sign \
+          cosign sign --yes \
             -a 'repo=${{ github.repository }}' \
             -a 'workflow=${{ github.workflow }}' \
             -a 'ref=${{ github.sha }}' \


### PR DESCRIPTION
Relates to #209, #213, #225

## Summary

Update the invocation of `cosign sign` in the continuous deployment pipeline to include the `--yes` flag in order to avoid being prompted for keyless signing. This is based on the [(v3.0.1) documentation of the `cosign-installer` action](https://github.com/sigstore/cosign-installer/tree/v3.0.1). This addresses the CD failure [here](https://github.com/ericcornelissen/js-regex-security-scanner/actions/runs/4407844114).