### PR TITLE
Set up Prettier for JavaScript linting

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -116,6 +116,9 @@ jobs:
       - name: Lint Dockerfile
         if: ${{ failure() || success() }}
         run: make lint-docker
+      - name: Lint JavaScript
+        if: ${{ failure() || success() }}
+        run: make lint-js
       - name: Lint MarkDown
         if: ${{ failure() || success() }}
         run: make lint-md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,12 +126,13 @@ make lint
 
 to run all linters or use the following commands to check specific file types:
 
-| File type        | Command            | Linter(s)                   |
-| :--------------- | :----------------- | :-------------------------- |
-| CI workflows     | `make lint-ci`     | [actionlint] & [ShellCheck] |
-| `Dockerfile`     | `make lint-docker` | [hadolint]                  |
-| MarkDown (`.md`) | `make lint-md`     | [markdownlint]              |
-| YAML (`.yml`)    | `make lint-yml`    | [yamllint]                  |
+| File type          | Command            | Linter(s)                   |
+| :----------------- | :----------------- | :-------------------------- |
+| CI workflows       | `make lint-ci`     | [actionlint] & [ShellCheck] |
+| `Dockerfile`       | `make lint-docker` | [hadolint]                  |
+| JavaScript (`.js`) | `make lint-js`     | [Prettier]                  |
+| MarkDown (`.md`)   | `make lint-md`     | [markdownlint]              |
+| YAML (`.yml`)      | `make lint-yml`    | [yamllint]                  |
 
 #### Testing
 
@@ -225,6 +226,7 @@ make audit-npm
 [node.js]: https://nodejs.org/en/
 [npm]: https://www.npmjs.com/
 [open issues]: https://github.com/ericcornelissen/js-regex-security-scanner/issues
+[prettier]: https://prettier.io/
 [security policy]: ./SECURITY.md
 [shellcheck]: https://github.com/koalaman/shellcheck
 [submodule]: https://git-scm.com/book/en/v2/Git-Tools-Submodules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,9 +116,15 @@ To build the Docker image for this scanner, run:
 make build
 ```
 
-#### Linting
+#### Formatting and Linting
 
-This project uses linters to catch mistakes and enforce style. Run:
+This project uses formatters to format source code. Run:
+
+```shell
+make format
+```
+
+This project also uses linters to catch mistakes and enforce style. Run:
 
 ```shell
 make lint

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,21 @@ clean: ## Clean the repository
 	@docker rmi --force \
 		$(IMAGE_NAME)
 
+format: format-js ## Format the project
+
+format-js: $(NODE_MODULES) ## Format JavaScript files
+	@npx prettier \
+		--write \
+		--ignore-path .gitignore \
+		\
+		--arrow-parens always \
+		--end-of-line lf \
+		--trailing-comma all \
+		--use-tabs \
+		\
+		./scripts/*.js \
+		./tests/*.js
+
 help: ## Show this help message
 	@printf "Usage: make <command>\n\n"
 	@printf "Commands:\n"
@@ -102,6 +117,7 @@ verify: build license-check lint test ## Verify project is in a good state
 .PHONY: default help \
 	build clean init sbom verify \
 	audit audit-docker audit-npm \
+	format format-js \
 	license-check license-check-docker license-check-npm \
 	lint lint-ci lint-docker lint-js lint-md lint-yml \
 	test update-test-snapshots

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ license-check-npm: $(NODE_MODULES) ## Check npm dependency licenses
 	@npx licensee \
 		--errors-only
 
-lint: lint-ci lint-docker lint-md lint-yml ## Lint the project
+lint: lint-ci lint-docker lint-js lint-md lint-yml ## Lint the project
 
 lint-ci: $(TOOLING) ## Lint Continuous Integration configuration files
 	@actionlint
@@ -58,6 +58,19 @@ lint-ci: $(TOOLING) ## Lint Continuous Integration configuration files
 lint-docker: $(TOOLING) ## Lint the Dockerfile
 	@hadolint \
 		Dockerfile
+
+lint-js: $(NODE_MODULES) ## Lint JavaScript files
+	@npx prettier \
+		--check \
+		--ignore-path .gitignore \
+		\
+		--arrow-parens always \
+		--end-of-line lf \
+		--trailing-comma all \
+		--use-tabs \
+		\
+		./scripts/*.js \
+		./tests/*.js
 
 lint-md: $(NODE_MODULES) ## Lint MarkDown files
 	@npx markdownlint \
@@ -90,7 +103,7 @@ verify: build license-check lint test ## Verify project is in a good state
 	build clean init sbom verify \
 	audit audit-docker audit-npm \
 	license-check license-check-docker license-check-npm \
-	lint lint-ci lint-docker lint-md lint-yml \
+	lint lint-ci lint-docker lint-js lint-md lint-yml \
 	test update-test-snapshots
 
 $(SBOM_FILE): $(TOOLING) $(DOCKERIMAGES)/latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
       "devDependencies": {
         "ava": "5.1.1",
         "licensee": "10.0.0",
-        "markdownlint-cli": "0.33.0"
+        "markdownlint-cli": "0.33.0",
+        "prettier": "2.8.7"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -4351,6 +4352,21 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-ms": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "ava": "5.1.1",
     "licensee": "10.0.0",
-    "markdownlint-cli": "0.33.0"
+    "markdownlint-cli": "0.33.0",
+    "prettier": "2.8.7"
   }
 }

--- a/scripts/bump-changelog.js
+++ b/scripts/bump-changelog.js
@@ -10,11 +10,7 @@ const STR_UNRELEASED = "## [Unreleased]";
 const STR_NO_CHANGES = "- _No changes yet_";
 
 const projectRoot = path.resolve(
-	path.dirname(
-		url.fileURLToPath(
-			new URL(import.meta.url),
-		),
-	),
+	path.dirname(url.fileURLToPath(new URL(import.meta.url))),
 	"..",
 );
 
@@ -22,14 +18,8 @@ const projectRoot = path.resolve(
 // Paths & Files
 // -------------
 
-const changelogFilePath = path.resolve(
-	projectRoot,
-	"CHANGELOG.md",
-);
-const dockerFilePath = path.resolve(
-	projectRoot,
-	"Dockerfile",
-);
+const changelogFilePath = path.resolve(projectRoot, "CHANGELOG.md");
+const dockerFilePath = path.resolve(projectRoot, "Dockerfile");
 
 const dockerFileRaw = fs.readFileSync(dockerFilePath).toString();
 const changelogRaw = fs.readFileSync(changelogFilePath).toString();
@@ -38,10 +28,11 @@ const changelogRaw = fs.readFileSync(changelogFilePath).toString();
 // Current version
 // ---------------
 
-const versionLabel = dockerFileRaw.split(/\n/)
-	.map(line => line.trim())
-	.find(line => line.startsWith("version="));
-const version = versionLabel.split("\"")[1];
+const versionLabel = dockerFileRaw
+	.split(/\n/)
+	.map((line) => line.trim())
+	.find((line) => line.startsWith("version="));
+const version = versionLabel.split('"')[1];
 
 // ----------
 // Validation

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -4,24 +4,18 @@ import * as process from "node:process";
 import * as url from "node:url";
 
 const projectRoot = path.resolve(
-	path.dirname(
-		url.fileURLToPath(
-			new URL(import.meta.url),
-		),
-	),
+	path.dirname(url.fileURLToPath(new URL(import.meta.url))),
 	"..",
 );
-const dockerFilePath = path.resolve(
-	projectRoot,
-	"Dockerfile",
-);
+const dockerFilePath = path.resolve(projectRoot, "Dockerfile");
 
 const dockerFileRaw = fs.readFileSync(dockerFilePath).toString();
 
-const versionLabel = dockerFileRaw.split(/\n/)
-	.map(line => line.trim())
-	.find(line => line.startsWith("version="));
-const version = versionLabel.split("\"")[1];
+const versionLabel = dockerFileRaw
+	.split(/\n/)
+	.map((line) => line.trim())
+	.find((line) => line.startsWith("version="));
+const version = versionLabel.split('"')[1];
 
 const versionTuple = version.split(".");
 switch (process.argv[2]) {

--- a/scripts/check-licenses.js
+++ b/scripts/check-licenses.js
@@ -7,20 +7,14 @@ import * as url from "node:url";
 // Ecosystems
 // ----------
 
-const skipEcosystems = [
-	"npm",
-];
+const skipEcosystems = ["npm"];
 
 // ---------
 // Utilities
 // ---------
 
 const projectRoot = path.resolve(
-	path.dirname(
-		url.fileURLToPath(
-			new URL(import.meta.url),
-		),
-	),
+	path.dirname(url.fileURLToPath(new URL(import.meta.url))),
 	"..",
 );
 
@@ -35,13 +29,11 @@ const toMatchWholeWordExpression = (string) => {
 };
 
 const isAllowedLicense = (license) => {
-	return allowedLicenses
-		.map(toMatchWholeWordExpression)
-		.some(matches(license));
+	return allowedLicenses.map(toMatchWholeWordExpression).some(matches(license));
 };
 
 const applyCorrection = (artifact) => {
-	const correction = corrections.find(entry => entry.name === artifact.name);
+	const correction = corrections.find((entry) => entry.name === artifact.name);
 	return {
 		...artifact,
 		licenses: correction?.licenses ?? artifact.licenses,
@@ -55,28 +47,23 @@ const applyCorrection = (artifact) => {
 const corrections = [
 	{
 		name: "busybox",
-		licenses: [
-			"GPL-2.0-only",
-		],
+		licenses: ["GPL-2.0-only"],
 		licenseUrl: "https://busybox.net/license.html",
-		reason: "license not detected by Syft"
+		reason: "license not detected by Syft",
 	},
 	{
 		name: "node",
-		licenses: [
-			"MIT",
-		],
+		licenses: ["MIT"],
 		licenseUrl: "https://github.com/nodejs/node#license",
-		reason: "license not detected by Syft"
+		reason: "license not detected by Syft",
 	},
 ];
 
-const licenseConfigFile = path.resolve(
-	projectRoot,
-	".licensee.json",
-);
+const licenseConfigFile = path.resolve(projectRoot, ".licensee.json");
 
-const licenseConfigRaw = fs.readFileSync(licenseConfigFile, { encoding: "utf8" });
+const licenseConfigRaw = fs.readFileSync(licenseConfigFile, {
+	encoding: "utf8",
+});
 const licenseConfig = JSON.parse(licenseConfigRaw);
 
 const allowedLicenses = licenseConfig.licenses.spdx;
@@ -85,10 +72,7 @@ const allowedLicenses = licenseConfig.licenses.spdx;
 // Load the SBOM
 // -------------
 
-const sbomFile = path.resolve(
-	projectRoot,
-	"sbom.json",
-);
+const sbomFile = path.resolve(projectRoot, "sbom.json");
 
 const rawSbom = fs.readFileSync(sbomFile);
 const sbom = JSON.parse(rawSbom);
@@ -98,10 +82,10 @@ const sbom = JSON.parse(rawSbom);
 // -----------------
 
 const licenseViolations = sbom.artifacts
-	.filter(artifact => !skipEcosystems.includes(artifact.type))
+	.filter((artifact) => !skipEcosystems.includes(artifact.type))
 	.map(applyCorrection)
-	.filter(artifact => !artifact.licenses.some(isAllowedLicense))
-	.map(artifact => {
+	.filter((artifact) => !artifact.licenses.some(isAllowedLicense))
+	.map((artifact) => {
 		return {
 			licenses: artifact.licenses,
 			name: artifact.name,
@@ -114,7 +98,7 @@ const licenseViolations = sbom.artifacts
 // --------------
 
 if (licenseViolations.length > 0) {
-	licenseViolations.forEach(licenseViolation => {
+	licenseViolations.forEach((licenseViolation) => {
 		const multipleLicenses = licenseViolation.licenses.length > 1;
 		console.log(
 			"The",
@@ -123,7 +107,7 @@ if (licenseViolations.length > 0) {
 			quoted(licenseViolation.name),
 			"is licensed under",
 			multipleLicenses
-				? licenseViolation.licenses.map(quoted).join(' and ')
+				? licenseViolation.licenses.map(quoted).join(" and ")
 				: quoted(licenseViolation.licenses[0]),
 			"which",
 			multipleLicenses ? "are" : "is",

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -12,7 +12,7 @@ const testdataDir = path.resolve(
 );
 
 for (const project of fs.readdirSync(testdataDir)) {
-	test(project, t => {
+	test(project, (t) => {
 		const dirPath = path.resolve(testdataDir, project);
 
 		const argsPath = path.resolve(dirPath, ".args");


### PR DESCRIPTION
Closes #76 

## Summary

Add [Prettier] as a devDependency and use it for linting JavaScript files, in particular to enforce a consistent style across the project. A `Makefile` target is provided to lint just JavaScript files, this is also where the configuration of Prettier lives (this may be re-evaluated in the future). The `make lint` target is updated to also lint `.js` files. The "Check / Lint" job has been updated to lint JavaScript files. Finally, the Contributing Guidelines have been updated to cover linting of JavaScript files as well.

JavaScript files in the `testdata/` directory aren't linter because 1) their style is less relevant as they're not meant to be read or edited (regularly), and 2) this can get messy with submodules.

[prettier]: https://prettier.io/