### PR TITLE
Update "Getting started"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ expressions.
 ## Getting started
 
 The scanner is available as a [Docker] image that you can run against any
-JavaScript or TypeScript project - for example:
+JavaScript or TypeScript project. For example, to scan the current directory:
 
 ```shell
 docker run --rm -v $(pwd):/project ericornelissen/js-re-scan:latest


### PR DESCRIPTION
## Summary

Adjust the copy of the "Getting started" section for clarity. Explicitly state that the example is to scan the current directory. This was changed as not every reader may know that `$(pwd)` expands to the full path of the current working directory of the shell.