### PR TITLE
Support building with Podman

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,16 @@ jobs:
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            auth.docker.io:443
+            github.com:443
+            nodejs.org:443
+            objects.githubusercontent.com:443
+            production.cloudflare.docker.com:443
+            registry-1.docker.io:443
+            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - name: Build

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,27 +15,24 @@ jobs:
     needs:
       - build
   build:
-    name: Build
+    name: Build with ${{ matrix.engine }}
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        engine:
+          - docker
+          - podman
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776 # v2.2.1
         with:
           disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            auth.docker.io:443
-            github.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            production.cloudflare.docker.com:443
-            registry-1.docker.io:443
-            registry.npmjs.org:443
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - name: Build
-        run: make build
+        run: make build ENGINE='${{ matrix.engine }}'
   licenses:
     name: Licenses
     runs-on: ubuntu-22.04

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -152,10 +152,16 @@ jobs:
         with:
           sarif_file: semgrep.sarif
   test:
-    name: Test
+    name: Test with ${{ matrix.engine }}
     runs-on: ubuntu-22.04
     needs:
       - build
+    strategy:
+      fail-fast: false
+      matrix:
+        engine:
+          - docker
+          - podman
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
@@ -182,4 +188,4 @@ jobs:
           node-version: 18
           cache: npm
       - name: Test
-        run: make test
+        run: make test ENGINE='${{ matrix.engine }}'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -79,9 +79,9 @@ jobs:
           cache: npm
       - name: Install tooling
         uses: asdf-vm/actions/install@75bab86b342b8aa14f3b547296607599522cbe90 # v2.1.0
-      - name: Check Docker licenses
+      - name: Check container image licenses
         if: ${{ failure() || success() }}
-        run: make license-check-docker
+        run: make license-check-image
       - name: Check npm licenses
         if: ${{ failure() || success() }}
         run: make license-check-npm
@@ -121,7 +121,7 @@ jobs:
         run: make lint-ci
       - name: Lint Dockerfile
         if: ${{ failure() || success() }}
-        run: make lint-docker
+        run: make lint-image
       - name: Lint JavaScript
         if: ${{ failure() || success() }}
         run: make lint-js

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -11,8 +11,8 @@ on:
 permissions: read-all
 
 jobs:
-  docker:
-    name: Docker
+  image:
+    name: Image
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -47,8 +47,8 @@ jobs:
           ref: ${{ matrix.ref }}
       - name: Install tooling
         uses: asdf-vm/actions/install@75bab86b342b8aa14f3b547296607599522cbe90 # v2.1.0
-      - name: Audit dependencies in Docker image
-        run: make audit-docker
+      - name: Audit dependencies in container image
+        run: make audit-image
       - name: Upload SBOM and vulnerability scan
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: ${{ failure() || success() }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,15 +102,16 @@ If you decide to make a contribution, please do use the following workflow:
 ### Development Details
 
 This scanner is in essence running [ESLint] with a specific configuration in a
-[Docker] image. As a first principle, all changes should be made by adjusting
+container image. As a first principle, all changes should be made by adjusting
 this setup. This means the two most important files are:
 
 - `.eslintrc.yml`: The [ESLint] configuration file.
-- `Dockerfile`: The file telling [Docker] how to make the scanner image.
+- `Dockerfile`: The file telling [Docker] (or [Podman]) how to make the scanner
+  image.
 
 #### Building
 
-To build the Docker image for this scanner, run:
+To build the container image for this scanner, run:
 
 ```shell
 make build
@@ -138,13 +139,13 @@ make lint
 
 to run all linters or use the following commands to check specific file types:
 
-| File type          | Command            | Linter(s)                   |
-| :----------------- | :----------------- | :-------------------------- |
-| CI workflows       | `make lint-ci`     | [actionlint] & [ShellCheck] |
-| `Dockerfile`       | `make lint-docker` | [hadolint]                  |
-| JavaScript (`.js`) | `make lint-js`     | [Prettier]                  |
-| MarkDown (`.md`)   | `make lint-md`     | [markdownlint]              |
-| YAML (`.yml`)      | `make lint-yml`    | [yamllint]                  |
+| File type          | Command           | Linter(s)                   |
+| :----------------- | :---------------- | :-------------------------- |
+| CI workflows       | `make lint-ci`    | [actionlint] & [ShellCheck] |
+| `Dockerfile`       | `make lint-image` | [hadolint]                  |
+| JavaScript (`.js`) | `make lint-js`    | [Prettier]                  |
+| MarkDown (`.md`)   | `make lint-md`    | [markdownlint]              |
+| YAML (`.yml`)      | `make lint-yml`   | [yamllint]                  |
 
 #### Testing
 
@@ -233,16 +234,16 @@ To generate a Software Bill Of Materials (SBOM) at `./sbom.json`, run:
 make sbom
 ```
 
-This uses [Syft] to generate an SBOM for the Docker image.
+This uses [Syft] to generate an SBOM for the container image.
 
 ### Vulnerability Scanning
 
-#### Docker
+#### Container Image
 
-To get a vulnerability report for the Docker image at `./vulns.json`, run:
+To get a vulnerability report for the container image at `./vulns.json`, run:
 
 ```shell
-make audit-docker
+make audit-image
 ```
 
 This uses [Grype] to determine vulnerabilities based on the SBOM (excluding

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,12 @@ To run the tests, run:
 make test
 ```
 
+Or to run the tests using Podman, run:
+
+```shell
+make test ENGINE=podman
+```
+
 ##### Updating Snapshots
 
 If you made changes to the scanner, it is likely necessary to update the test
@@ -174,6 +180,12 @@ snapshots. To do this, run:
 
 ```shell
 make update-test-snapshots
+```
+
+Or using Podman:
+
+```shell
+make update-test-snapshots ENGINE=podman
 ```
 
 ##### Writing Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ as clearly as possible.
 To be able to contribute you need at least the following:
 
 - [Git];
-- [Docker];
+- [Docker] (or [Podman]);
 - [Make];
 - [Node.js] v18.0.0 or higher and [npm] v8.1.2 or higher;
 - (Recommended) a code editor with [EditorConfig] support;
@@ -114,6 +114,12 @@ To build the Docker image for this scanner, run:
 
 ```shell
 make build
+```
+
+Or to build using Podman, run:
+
+```shell
+make build ENGINE=podman
 ```
 
 #### Formatting and Linting
@@ -253,6 +259,7 @@ make audit-npm
 [node.js]: https://nodejs.org/en/
 [npm]: https://www.npmjs.com/
 [open issues]: https://github.com/ericcornelissen/js-regex-security-scanner/issues
+[podman]: https://podman.io/
 [prettier]: https://prettier.io/
 [security policy]: ./SECURITY.md
 [shellcheck]: https://github.com/koalaman/shellcheck

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,14 @@ VULN_FILE:=vulns.json
 
 default: help
 
-audit: audit-docker audit-npm ## Audit the project dependencies
+audit: audit-image audit-npm ## Audit the project dependencies
 
-audit-docker: $(VULN_FILE) ## Audit the Docker image dependencies
+audit-image: $(VULN_FILE) ## Audit the container image dependencies
 
 audit-npm: ## Audit the npm dependencies
 	@npm audit $(ARGS)
 
-build: $(IMAGES_DIR)/$(TAG) ## Build the Docker image
+build: $(IMAGES_DIR)/$(TAG) ## Build the container image
 
 clean: ## Clean the repository
 	@git clean -fx \
@@ -57,21 +57,21 @@ help: ## Show this help message
 
 init: $(NODE_MODULES) ## Initialize the project dependencies
 
-license-check: license-check-docker license-check-npm ## Check the project dependency licenses
+license-check: license-check-image license-check-npm ## Check the project dependency licenses
 
-license-check-docker: $(SBOM_FILE) ## Check Docker image dependency licenses
+license-check-image: $(SBOM_FILE) ## Check container image dependency licenses
 	@node scripts/check-licenses.js
 
 license-check-npm: $(NODE_MODULES) ## Check npm dependency licenses
 	@npx licensee \
 		--errors-only
 
-lint: lint-ci lint-docker lint-js lint-md lint-yml ## Lint the project
+lint: lint-ci lint-image lint-js lint-md lint-yml ## Lint the project
 
 lint-ci: $(TOOLING) ## Lint Continuous Integration configuration files
 	@actionlint
 
-lint-docker: $(TOOLING) ## Lint the Dockerfile
+lint-image: $(TOOLING) ## Lint the Dockerfile
 	@hadolint \
 		Dockerfile
 
@@ -119,10 +119,10 @@ verify: build license-check lint test ## Verify project is in a good state
 
 .PHONY: default help \
 	build clean init sbom verify \
-	audit audit-docker audit-npm \
+	audit audit-image audit-npm \
 	format format-js \
-	license-check license-check-docker license-check-npm \
-	lint lint-ci lint-docker lint-js lint-md lint-yml \
+	license-check license-check-image license-check-npm \
+	lint lint-ci lint-image lint-js lint-md lint-yml \
 	test update-test-snapshots
 
 $(SBOM_FILE): $(TOOLING) $(IMAGES_DIR)/latest

--- a/Makefile
+++ b/Makefile
@@ -104,12 +104,14 @@ lint-yml: $(TOOLING) ## Lint .yml files
 sbom: $(SBOM_FILE) ## Generate a Software Bill Of Materials (SBOM)
 
 test: build $(NODE_MODULES) ## Run the tests
-	@npx ava \
+	@CONTAINER_ENGINE=$(ENGINE) \
+		npx ava \
 		--timeout 20s \
 		tests/
 
 update-test-snapshots: build $(NODE_MODULES) ## Update the test snapsthos
-	@npx ava \
+	@CONTAINER_ENGINE=$(ENGINE) \
+		npx ava \
 		--update-snapshots \
 		tests/
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ DOCKERIMAGES:=$(TEMP_DIR)/dockerimages
 SBOM_FILE:=sbom.json
 VULN_FILE:=vulns.json
 
+ENGINE?=docker
 TAG?=latest
 
 default: help
@@ -29,7 +30,7 @@ clean: ## Clean the repository
 		$(NODE_MODULES) \
 		$(SBOM_FILE) \
 		$(VULN_FILE)
-	@docker rmi --force \
+	@$(ENGINE) rmi --force \
 		$(IMAGE_NAME)
 
 format: format-js ## Format the project
@@ -143,5 +144,5 @@ endif
 $(DOCKERIMAGES): | $(TEMP_DIR)
 	@mkdir $(DOCKERIMAGES)
 $(DOCKERIMAGES)/%: .dockerignore .eslintrc.yml Dockerfile package*.json | $(DOCKERIMAGES)
-	@docker build --tag $(IMAGE_NAME):$(TAG) .
+	@$(ENGINE) build --tag $(IMAGE_NAME):$(TAG) .
 	@touch $(DOCKERIMAGES)/$(TAG)

--- a/README.md
+++ b/README.md
@@ -5,12 +5,15 @@ expressions.
 
 ## Getting started
 
-The scanner is available as a [Docker] image that you can run against any
+The scanner is available as a container image that you can run against any
 JavaScript or TypeScript project. For example, to scan the current directory:
 
 ```shell
-docker run --rm -v $(pwd):/project ericornelissen/js-re-scan:latest
+docker run --rm -v $(pwd):/project docker.io/ericornelissen/js-re-scan:latest
 ```
+
+> **Note**: You can replace `docker` by `podman` in any command example if you
+> want to use [Podman] instead [Docker].
 
 ### Ignore patterns
 
@@ -19,7 +22,7 @@ If necessary you can ignore certain files or directories using the option
 in your own project you can use:
 
 ```shell
-docker run --rm -v $(pwd):/project ericornelissen/js-re-scan:latest  \
+docker run --rm -v $(pwd):/project docker.io/ericornelissen/js-re-scan:latest  \
   --ignore-pattern vendor/
 ```
 
@@ -44,8 +47,8 @@ The scanner has the following exit codes.
 
 ## Build from source
 
-If you want you can build the scanner from scratch using [Docker]. From the root
-of this project run something like:
+If you want you can build the scanner from scratch. From the root of this
+project run something like:
 
 ```shell
 docker build . --tag js-regex-scanner
@@ -95,4 +98,5 @@ how to improve the documentation.
 [license]: ./LICENSE
 [make]: https://www.gnu.org/software/make/
 [open an issue]: https://github.com/ericcornelissen/js-regex-security-scanner/issues/new?labels=documentation&template=documentation.md
+[podman]: https://podman.io/
 [redos-detector]: https://github.com/tjenkinson/redos-detector

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,6 +1,7 @@
 import cp from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import process from "node:process";
 import url from "node:url";
 
 import test from "ava";
@@ -22,7 +23,7 @@ for (const project of fs.readdirSync(testdataDir)) {
 		}
 
 		const { stdout } = cp.spawnSync(
-			"docker",
+			process.env.CONTAINER_ENGINE,
 			[
 				"run",
 				"--rm",


### PR DESCRIPTION
## Summary

Update the Makefile to support building the scanner image with [Podman] instead of [Docker]. The aim being to support both engines so users will be able to choose which one they want to use. 

~~More "support" for Podman, such as running the tests with Podman, may be added later. It may also make sense to change some of the terminology away from "docker" (e.g. the `audit-docker` target), again this is considered a task for later.~~

[podman]: https://podman.io/
[docker]: https://www.docker.com/