### PR TITLE
Use old target for auditing the `v0` ref

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -49,6 +49,13 @@ jobs:
         uses: asdf-vm/actions/install@75bab86b342b8aa14f3b547296607599522cbe90 # v2.1.0
       - name: Audit dependencies in container image
         run: make audit-image
+        # The 4 lines following this comment block, as well as the block itself,
+        # should be removed when the `make audit-image` target is available at
+        # the `v0` ref.
+        if: ${{ matrix.ref != 'v0' }}
+      - name: Audit dependencies in container image
+        if: ${{ matrix.ref == 'v0' }}
+        run: make audit-docker
       - name: Upload SBOM and vulnerability scan
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: ${{ failure() || success() }}


### PR DESCRIPTION
Relates to #250

## Summary

The Make target for auditing the container image is currently different between the `main` branch ref and the `v0` ref. As such, the [nightly auditing job fails](https://github.com/ericcornelissen/js-regex-security-scanner/actions/runs/4643088792/jobs/8217496735) because the executed target doesn't exist at the `v0` ref. To solve this, the command to audit the container image is made conditional on the ref.