### PR TITLE
Document license compliance in the Contributing Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,6 +226,35 @@ arguments found in this file.
 
 ## Auditing
 
+### License Compliance
+
+To verify that all dependency licenses are in compliance with the defined
+policy, run the following command:
+
+```shell
+make license-check
+```
+
+The policy is defined in `.licensee.json`. The table below explains why the
+license is allowed for this project. Note that licenses are added to the policy
+only when observed in a dependency of the project.
+
+|            License | Reason                                 |
+| -----------------: | :------------------------------------- |
+|             `0BSD` | Permissive                             |
+|       `Apache-2.0` | Permissive                             |
+|     `BSD-2-Clause` | Permissive                             |
+|     `BSD-3-Clause` | Permissive                             |
+|     `GPL-2.0-only` | OK under the 'mere aggregation' clause |
+| `GPL-2.0-or-later` | OK under the 'mere aggregation' clause |
+|          `CC0-1.0` | Public domain                          |
+|        `CC-BY-3.0` | Public domain                          |
+|              `ISC` | Permissive                             |
+|              `MIT` | Permissive                             |
+|          `openssl` | Permissive                             |
+|       `Python-2.0` | Permissive                             |
+|             `zlib` | Permissive                             |
+
 ### SBOM
 
 To generate a Software Bill Of Materials (SBOM) at `./sbom.json`, run:


### PR DESCRIPTION
Supersedes #260
Relates to #60, #121

## Summary

Document the `make license-check` command in the Contributing Guidelines. Also include reasoning for allowing every allowlisted license in the project to:

1. make intent clearer, and
2. allow for more constructive public review.