### PR TITLE
Update egress policy for "Publish / Docker Hub"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,7 @@ jobs:
             auth.docker.io:443
             fulcio.sigstore.dev:443
             github.com:443
+            index.docker.io:443
             nodejs.org:443
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443


### PR DESCRIPTION
Relates to #269

## Summary

Update the [harden-runner](https://github.com/step-security/harden-runner) egress policy for the CD job that publishes the scanner image to [Docker hub](https://hub.docker.com/) to allow an in-practice observed endpoint which (seems to have) caused the automated release of v0.4.3 to have failed
