### PR TITLE
Bump Node.js from 18 to 20

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: 18
           cache: npm
+          node-version: 20
       - name: Install tooling
         uses: asdf-vm/actions/install@75bab86b342b8aa14f3b547296607599522cbe90 # v2.1.0
       - name: Check container image licenses
@@ -112,8 +112,8 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: 18
           cache: npm
+          node-version: 20
       - name: Install tooling
         uses: asdf-vm/actions/install@75bab86b342b8aa14f3b547296607599522cbe90 # v2.1.0
       - name: Lint CI
@@ -185,7 +185,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: 18
           cache: npm
+          node-version: 20
       - name: Test
         run: make test ENGINE='${{ matrix.engine }}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -139,7 +139,7 @@ jobs:
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
           cache: npm
-          node-version: 18
+          node-version: 20
       - name: Install tooling
         uses: asdf-vm/actions/install@75bab86b342b8aa14f3b547296607599522cbe90 # v2.1.0
       - name: Verify project validity

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: 18
           cache: npm
+          node-version: 20
       - name: Create token to create Pull Request
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
         id: pull_request_token

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -86,8 +86,8 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: 18
           cache: npm
+          node-version: 20
       - name: Audit all npm dependencies
         if: ${{ !startsWith(matrix.ref, 'v') }}
         run: make audit-npm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ To be able to contribute you need at least the following:
 - [Git];
 - [Docker] (or [Podman]);
 - [Make];
-- [Node.js] v18.0.0 or higher and [npm] v8.1.2 or higher;
+- [Node.js] v20.0.0 or higher and [npm] v8.1.2 or higher;
 - (Recommended) a code editor with [EditorConfig] support;
 - (Optional) [actionlint] (see `.tool-versions` for preferred version);
 - (Optional) [Grype] (see `.tool-versions` for preferred version);

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:18.16.0-alpine3.17
+FROM node:20.0.0-alpine3.17
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "js-regex-security-scanner",
       "dependencies": {
         "@typescript-eslint/parser": "5.58.0",
         "eslint": "8.38.0",
@@ -18,7 +17,7 @@
         "prettier": "2.8.7"
       },
       "engines": {
-        "node": ">=18.0.0",
+        "node": ">=20.0.0",
         "npm": ">=8.1.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "private": true,
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "npm": ">=8.1.2"
   },
   "dependencies": {


### PR DESCRIPTION
Closes #280

## Summary

Upgrade from Node.js v18 to the next LTS release v20. Applied to the `Dockerfile` as well as all development uses of Node.js