### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,7 +98,7 @@ jobs:
           tags: >-
             ericornelissen/js-re-scan:latest,
             ericornelissen/js-re-scan:${{ steps.version.outputs.result }}
-      - name: Sign container image (experimental)
+      - name: Sign container image
         run: |
           cosign sign --yes \
             -a 'repo=${{ github.repository }}' \


### PR DESCRIPTION
Relates to #125, #132, #209

## Summary

Remove the ` (experimental)` suffix from the cosign signing step as the usage of keyless signing i no longer experimental.