### PR TITLE
Update license policy

### DIFF
--- a/.licensee.json
+++ b/.licensee.json
@@ -6,8 +6,6 @@
       "BlueOak-1.0.0",
       "BSD-2-Clause",
       "BSD-3-Clause",
-      "GPL-2.0-only",
-      "GPL-2.0-or-later",
       "CC0-1.0",
       "CC-BY-3.0",
       "ISC",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,22 +239,20 @@ The policy is defined in `.licensee.json`. The table below explains why the
 license is allowed for this project. Note that licenses are added to the policy
 only when observed in a dependency of the project.
 
-|            License | Reason                                 |
-| -----------------: | :------------------------------------- |
-|             `0BSD` | Permissive                             |
-|       `Apache-2.0` | Permissive                             |
-|    `BlueOak-1.0.0` | Permissive                             |
-|     `BSD-2-Clause` | Permissive                             |
-|     `BSD-3-Clause` | Permissive                             |
-|     `GPL-2.0-only` | OK under the 'mere aggregation' clause |
-| `GPL-2.0-or-later` | OK under the 'mere aggregation' clause |
-|          `CC0-1.0` | Public domain                          |
-|        `CC-BY-3.0` | Public domain                          |
-|              `ISC` | Permissive                             |
-|              `MIT` | Permissive                             |
-|          `openssl` | Permissive                             |
-|       `Python-2.0` | Permissive                             |
-|             `zlib` | Permissive                             |
+|            License | Reason        |
+| -----------------: | :-------------|
+|             `0BSD` | Permissive    |
+|       `Apache-2.0` | Permissive    |
+|    `BlueOak-1.0.0` | Permissive    |
+|     `BSD-2-Clause` | Permissive    |
+|     `BSD-3-Clause` | Permissive    |
+|          `CC0-1.0` | Public domain |
+|        `CC-BY-3.0` | Public domain |
+|              `ISC` | Permissive    |
+|              `MIT` | Permissive    |
+|          `openssl` | Permissive    |
+|       `Python-2.0` | Permissive    |
+|             `zlib` | Permissive    |
 
 ### SBOM
 

--- a/scripts/check-licenses.js
+++ b/scripts/check-licenses.js
@@ -40,6 +40,14 @@ const applyCorrection = (artifact) => {
 	};
 };
 
+const applyException = (artifact) => {
+	const exception = exceptions.find((entry) => entry.name === artifact.name);
+	return {
+		...artifact,
+		exception: exception?.licenses.every((l, i) => l === artifact.licenses[i]),
+	};
+};
+
 // -----------
 // Load policy
 // -----------
@@ -58,6 +66,54 @@ const corrections = [
 		reason: "license not detected by Syft",
 	},
 ];
+
+const exceptions = [
+	{
+		name: "alpine-baselayout",
+		licenses: ["GPL-2.0-only"],
+		reason: "OK under the 'mere aggregation' clause",
+	},
+	{
+		name: "alpine-baselayout-data",
+		licenses: ["GPL-2.0-only"],
+		reason: "OK under the 'mere aggregation' clause",
+	},
+	{
+		name: "apk-tools",
+		licenses: ["GPL-2.0-only"],
+		reason: "OK under the 'mere aggregation' clause",
+	},
+	{
+		name: "busybox",
+		licenses: ["GPL-2.0-only"],
+		reason: "OK under the 'mere aggregation' clause",
+	},
+	{
+		name: "busybox-binsh",
+		licenses: ["GPL-2.0-only"],
+		reason: "OK under the 'mere aggregation' clause",
+	},
+	{
+		name: "libgcc",
+		licenses: ["GPL-2.0-or-later", "LGPL-2.1-or-later"],
+		reason: "OK under the 'mere aggregation' clause",
+	},
+	{
+		name: "libstdc++",
+		licenses: ["GPL-2.0-or-later", "LGPL-2.1-or-later"],
+		reason: "OK under the 'mere aggregation' clause",
+	},
+	{
+		name: "scanelf",
+		licenses: ["GPL-2.0-only"],
+		reason: "OK under the 'mere aggregation' clause",
+	},
+	{
+		name: "ssl_client",
+		licenses: ["GPL-2.0-only"],
+		reason: "OK under the 'mere aggregation' clause",
+	},
+]
 
 const licenseConfigFile = path.resolve(projectRoot, ".licensee.json");
 
@@ -84,6 +140,8 @@ const sbom = JSON.parse(rawSbom);
 const licenseViolations = sbom.artifacts
 	.filter((artifact) => !skipEcosystems.includes(artifact.type))
 	.map(applyCorrection)
+	.map(applyException)
+	.filter((artifact) => !artifact.exception)
 	.filter((artifact) => !artifact.licenses.some(isAllowedLicense))
 	.map((artifact) => {
 		return {


### PR DESCRIPTION
Relates to #60, #264

## Summary

Update the license policy to remove the blanket approval of dependencies licensed under `GPL-2.0-(only|or-later)` and instead use exceptions for individual dependencies to ensure the provided reason for allowing it actually applies.