### PR TITLE
Update the Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,39 +1,68 @@
 # Security Policy
 
+The maintainers of the _JavaScript Regex Security Scanner_ project take security
+issues seriously. We appreciate your efforts to responsibly disclose your
+findings. Due to the non-funded and open-source nature of the project, we take a
+best-efforts approach when it comes to engaging with security reports.
+
 ## Supported Versions
 
-The table below shows which versions of the _JavaScript Regex Security Scanner_
-are currently supported with security updates.
+The table below shows which versions of the project are currently supported
+with security updates.
 
-| Version | Supported | End-of-life |
-| ------: | :-------- | :---------- |
-|   0.x.x | Yes       | -           |
+| Version | End-of-life |
+| ------: | :---------- |
+|   0.x.x | -           |
+
+_This table only includes information on versions `<1.0.0`._
 
 ## Reporting a Vulnerability
 
-The maintainers of this project take security bugs very seriously. We appreciate
-your efforts to responsibly disclose your findings. Due to the non-funded and
-open-source nature of this project, we take a best-efforts approach when it
-comes to engaging with (security) reports.
+To report a security issue in the latest version of a supported version range,
+either:
 
-To report a security issue in a supported version of the project, send an email
-to [security@ericcornelissen.dev] and include the terms "SECURITY" and
-"js-re-scan" in the subject line. Please do not open a regular issue or Pull
-Request in the public repository.
+- [Report it through GitHub][new github advisory], or
+- Send an email to [security@ericcornelissen.dev] with the terms "SECURITY" and
+  "js-re-scan" in the subject line.
 
-If you found a security bug in an unsupported version of the project, please
-report this publicly. For example, as a regular issue in the public repository.
+Please do not open a regular issue or Pull Request in the public repository.
+
+To report a security issue in an unsupported version of the project, or if the
+latest version of a supported version range isn't affected, please report it
+publicly. For example, as a regular issue in the public repository. If in doubt,
+report the issue privately.
+
+[new github advisory]: https://github.com/ericcornelissen/js-regex-security-scanner/security/advisories/new
+[security@ericcornelissen.dev]: mailto:security@ericcornelissen.dev?subject=SECURITY%20%28js-re-scan%29
+
+### What to Include in a Report
+
+Try to include as many of the following items as possible in a security report:
+
+- An explanation of the issue
+- A proof of concept exploit
+- A suggested severity
+- Relevant [CWE] identifiers
+- The latest affected version
+- The earliest affected version
+- A suggested patch
+- An automated regression test
+
+[cwe]: https://cwe.mitre.org/
 
 ## Advisories
+
+> **Note**: Advisories will be created only for vulnerabilities present in
+> released versions of the project.
 
 | ID               | Date       | Affected versions | Patched versions |
 | :--------------- | :--------- | :---------------- | :--------------- |
 | -                | -          | -                 | -                |
+
+_This table is ordered most to least recent._
 
 ## Acknowledgments
 
 We would like to publicly thank the following reporters:
 
 - _None yet_
-
-[security@ericcornelissen.dev]: mailto:security@ericcornelissen.dev?subject=SECURITY%20%28js-re-scan%29


### PR DESCRIPTION
Relates to #35

## Summary

Rewrite the security policy for brevity and clarity, as well as to include the option to use GitHub's private vulnerability reporting option.

The intent of the security policy has not changed.