### PR TITLE
Add unnecessary license correction check

### DIFF
--- a/scripts/check-licenses.js
+++ b/scripts/check-licenses.js
@@ -22,6 +22,14 @@ const matches = (string) => (regexp) => regexp.test(string);
 
 const quoted = (string) => `'${string}'`;
 
+const setEqual = (collection1, collection2) => {
+	const set1 = new Set(collection1);
+	const set2 = new Set(collection2);
+	return (
+		set1.size === set2.size && set1.size === new Set([...set1, ...set2]).size
+	);
+};
+
 const toMatchWholeWordExpression = (string) => {
 	const preWordExpr = /(?:^|[\s(])/.source;
 	const postWordExpr = /(?:[\s)]|$)/.source;
@@ -34,9 +42,20 @@ const isAllowedLicense = (license) => {
 
 const applyCorrection = (artifact) => {
 	const correction = corrections.find((entry) => entry.name === artifact.name);
+	if (correction === undefined) {
+		return artifact;
+	}
+
+	if (setEqual(artifact.licenses, correction.licenses)) {
+		return {
+			...artifact,
+			unnecessaryCorrection: true,
+		};
+	}
+
 	return {
 		...artifact,
-		licenses: correction?.licenses ?? artifact.licenses,
+		licenses: correction.licenses,
 	};
 };
 
@@ -81,9 +100,11 @@ const sbom = JSON.parse(rawSbom);
 // Evaluate licenses
 // -----------------
 
-const licenseViolations = sbom.artifacts
+const licenseDataToEvaluate = sbom.artifacts
 	.filter((artifact) => !skipEcosystems.includes(artifact.type))
-	.map(applyCorrection)
+	.map(applyCorrection);
+
+const licenseViolations = licenseDataToEvaluate
 	.filter((artifact) => !artifact.licenses.some(isAllowedLicense))
 	.map((artifact) => {
 		return {
@@ -93,9 +114,29 @@ const licenseViolations = sbom.artifacts
 		};
 	});
 
+const unnecessaryCorrections = licenseDataToEvaluate
+	.filter((artifact) => artifact.unnecessaryCorrection)
+	.map((artifact) => {
+		return {
+			name: artifact.name,
+		};
+	});
+
 // --------------
 // Output results
 // --------------
+
+if (unnecessaryCorrections.length > 0) {
+	unnecessaryCorrections.forEach((artifact) => {
+		console.log("Unnecessary license correction for", quoted(artifact.name));
+	});
+
+	console.log(/* newline */);
+	console.log(
+		unnecessaryCorrections.length,
+		"unnecessary correction(s) detected. Please review",
+	);
+}
 
 if (licenseViolations.length > 0) {
 	licenseViolations.forEach((licenseViolation) => {
@@ -120,7 +161,9 @@ if (licenseViolations.length > 0) {
 		licenseViolations.length,
 		"license violation(s) detected. Please review",
 	);
+}
 
+if (licenseViolations.length > 0 || unnecessaryCorrections.length > 0) {
 	process.exit(1);
 } else {
 	console.log("No license violations detected");


### PR DESCRIPTION
Relates to #60, #130, #133

## Summary

Implement a check in the `check-licenses.js` script to look for license corrections that are not necessary. I.e., the SBOM contains the same license information as the correction.
