### PR TITLE
Update egress policies for jobs installing tooling with asdf

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -70,6 +70,7 @@ jobs:
             rekor.sigstore.dev:443
             sigstore-tuf-root.storage.googleapis.com:443
             toolbox-data.anchore.io:443
+            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout repository
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
       - name: Install Node.js
@@ -107,6 +108,7 @@ jobs:
             registry.npmjs.org:443
             rekor.sigstore.dev:443
             sigstore-tuf-root.storage.googleapis.com:443
+            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout repository
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
       - name: Install Node.js

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,6 +46,7 @@ jobs:
             pypi.org:443
             rekor.sigstore.dev:443
             sigstore-tuf-root.storage.googleapis.com:443
+            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout repository
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
       - name: Install tooling

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,6 +131,7 @@ jobs:
             rekor.sigstore.dev:443
             sigstore-tuf-root.storage.googleapis.com:443
             toolbox-data.anchore.io:443
+            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout repository
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
         with:

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -41,6 +41,7 @@ jobs:
             rekor.sigstore.dev:443
             sigstore-tuf-root.storage.googleapis.com:443
             toolbox-data.anchore.io:443
+            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout repository
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
         with:


### PR DESCRIPTION
Relates to #292

## Summary

Since using cosign 2.0.2 jobs installing tooling use a new endpoint during installation.