### PR TITLE
Make `mkdir` invocation POSIX compliant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ else ifneq (, $(shell which rtx))
 endif
 	@touch $(TOOLING)
 $(IMAGES_DIR): | $(TEMP_DIR)
-	@mkdir --parent $(IMAGES_DIR)
+	@mkdir -p $(IMAGES_DIR)
 $(IMAGES_DIR)/%: .dockerignore .eslintrc.yml Dockerfile package*.json | $(IMAGES_DIR)
 	@$(ENGINE) build --tag $(IMAGE_NAME):$(TAG) .
 	@touch $(IMAGES_DIR)/$(TAG)


### PR DESCRIPTION
Caused by #250

## Summary

Fix `make` targets that involved building for some contributors.

The [POSIX specification for `mkdir`](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/mkdir.html) only requires the `-p` flag, not the `--parent` flag. Hence, the old invocation could fail on some systems. Now using `-p` (reluctantly, as it hurts readability) when needing to make directories recursively.