### PR TITLE
Use fixed Node.js when auditing the v0 ref

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -89,6 +89,15 @@ jobs:
         with:
           cache: npm
           node-version-file: .nvmrc
+        # The 7 lines following this comment block, as well as the block itself,
+        # should be removed when the `.nvmrc` file is available at the `v0` ref.
+        if: ${{ matrix.ref != 'v0' }}
+      - if: ${{ matrix.ref == 'v0' }}
+        name: Install Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          cache: npm
+          node-version: 20
       - name: Audit all npm dependencies
         if: ${{ !startsWith(matrix.ref, 'v') }}
         run: make audit-npm


### PR DESCRIPTION
Caused by #302
Relates to #263

## Summary

Since #302 the project uses the `.nvmrc` file to record the Node.js version used for development as well as in Continuous Integration jobs. This file is not yet present on at the `v0` ref, which causes the nightly audit of `v0` to fail as seen in [this `nightly.yml` run](https://github.com/ericcornelissen/js-regex-security-scanner/actions/runs/4848079901).

This change should be reverted/removed when the `.nvmrc` file lands in the `v0` ref.
