### PR TITLE
Use the current commit SHA in the container scan artifact name

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -48,6 +48,11 @@ jobs:
           ref: ${{ matrix.ref }}
       - name: Install tooling
         uses: asdf-vm/actions/install@75bab86b342b8aa14f3b547296607599522cbe90 # v2.1.0
+      - name: Get git context
+        id: git
+        run: |
+          COMMIT_SHA="$(git rev-parse HEAD)"
+          echo "commit-sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
       - name: Audit dependencies in container image
         run: make audit-image
       - name: Upload SBOM and vulnerability scan
@@ -55,7 +60,7 @@ jobs:
         if: ${{ failure() || success() }}
         with:
           if-no-files-found: error
-          name: container-scan-${{ github.sha }}
+          name: container-scan-${{ steps.git.outputs.commit-sha }}
           path: |
             sbom.json
             vulns.json


### PR DESCRIPTION
Relates to 2f5ff4f2fdd4809974f81fc6ddb945e60d6acbcd, #300

## Summary

Use the checked out commit SHA instead of the GitHub context SHA for the uploaded `audit-image` artifact. The GitHub context SHA is the same regardless of the checked out commit, and for the `pull_request` target it's a non-existent commit (instead it's a staged merge of the HEAD and BASE). In the case of the nightly audit this means all audit artifacts will have the same `github.sha`, thus the same name, and thus override each other.