### PR TITLE
Rescope corrections to be based on `(name, foundBy)`

### DIFF
--- a/scripts/check-licenses.js
+++ b/scripts/check-licenses.js
@@ -42,7 +42,9 @@ const isAllowedLicense = (license) => {
 
 const applyCorrection = (artifact) => {
 	const correction = corrections.find(
-		(correction) => correction.id === artifact.id,
+		(correction) =>
+			correction.name === artifact.name &&
+			correction.foundBy === artifact.foundBy,
 	);
 	if (correction === undefined) {
 		return artifact;
@@ -75,15 +77,15 @@ const applyException = (artifact) => {
 
 const corrections = [
 	{
-		id: "e6c9486419cbb84e",
 		name: "busybox",
+		foundBy: "binary-cataloger",
 		licenses: ["GPL-2.0-only"],
 		licenseUrl: "https://busybox.net/license.html",
 		reason: "license not detected by Syft",
 	},
 	{
-		id: "da217ed84944a9a9",
 		name: "node",
+		foundBy: "binary-cataloger",
 		licenses: ["MIT"],
 		licenseUrl: "https://github.com/nodejs/node#license",
 		reason: "license not detected by Syft",


### PR DESCRIPTION
Relates to #297, #299

## Summary

Update how corrections are applied from using the `id` to using the `name`+`foundBy` values combined. Unfortunately, the `id` seems to vary in some cases so isn't suitable for corrections.

Using the `foundBy` value (in conjunction with the `name`) addresses the concern which originally addressed in #299 by switching to `id`-based corrections. Namely, if an artifact is `foundBy` multiple catalogers, the correction only applies to a specific cataloger's findings.
