### PR TITLE
Improve the note on using Podman instead of Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ JavaScript or TypeScript project. For example, to scan the current directory:
 docker run --rm -v $(pwd):/project docker.io/ericornelissen/js-re-scan:latest
 ```
 
-> **Note**: You can replace `docker` by `podman` in any command example if you
-> want to use [Podman] instead [Docker].
+> **Note**: To use [Podman] instead of [Docker] you can replace `docker` by
+> `podman` in any example command.
 
 ### Ignore patterns
 


### PR DESCRIPTION
Relates to #250

## Summary

Improve the note on using Podman instead of Docker by:
1. Putting the _what_ (using Podman) before to _how_ (replacing `docker` by `podman`).
2. Using "example command" instead of "command example" for better flow.