### PR TITLE
Ignore CVE-2023-2650

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -8,6 +8,8 @@ fail-on-severity: low
 ignore:
   # Ignore because this project isn't affected (no AES encryption is used).
   - vulnerability: CVE-2023-1255
+  # Ignore because  this project isn't affected (no ASN.1 object ids used).
+  - vulnerability: CVE-2023-2650
 
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:


### PR DESCRIPTION
Relates to #325

## Summary

Instruct [Grype](https://github.com/anchore/grype) to ignore CVE-2023-2650 as it does not impact this project and may only be fixed by either an OS update (depends on [Docker's Node.js image](https://hub.docker.com/_/node) releasing a new version) or manually installing a newer version of OpenSSL. The former is not possible as of this commit, the latter is not desired given this project isn't impacted to begin with.