### PR TITLE
Bump alpine from 3.17 to 3.18

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -6,8 +6,6 @@ file: vulns.json
 fail-on-severity: low
 
 ignore:
-  # Ignore because this project isn't affected (no AES encryption is used).
-  - vulnerability: CVE-2023-1255
   # Ignore because  this project isn't affected (no ASN.1 object ids used).
   - vulnerability: CVE-2023-2650
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
+- (`73df12e`) Bump Alpine from `3.17` to `3.18`.
 - (`8cfd729`) Bump ESLint from `8.39.0` to `8.40.0`.
 - (`4cae34b`) Bump ESLint from `8.40.0` to `8.41.0`.
 - (`c8c6675`) Bump ESLint from `8.41.0` to `8.42.0`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:20.2.0-alpine3.17
+FROM node:20.2.0-alpine3.18
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \

--- a/scripts/check-licenses.js
+++ b/scripts/check-licenses.js
@@ -125,12 +125,12 @@ const exceptions = [
 	},
 	{
 		name: "libgcc",
-		licenses: ["GPL-2.0-or-later", "LGPL-2.1-or-later"],
+		licenses: ["GPL-2.0-or-later AND LGPL-2.1-or-later"],
 		reason: "OK under the 'mere aggregation' clause",
 	},
 	{
 		name: "libstdc++",
-		licenses: ["GPL-2.0-or-later", "LGPL-2.1-or-later"],
+		licenses: ["GPL-2.0-or-later AND LGPL-2.1-or-later"],
 		reason: "OK under the 'mere aggregation' clause",
 	},
 	{


### PR DESCRIPTION
## Summary

Bumps the node base image from 20.2.0-alpine3.17 to 20.2.0-alpine3.18, thus bumping alpine from 3.17 to 3.18 while keeping Node.js at 20.2.0