### PR TITLE
Post v0.4.5 continuous integration updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,7 @@ jobs:
             rekor.sigstore.dev:443
             sigstore-tuf-root.storage.googleapis.com:443
             storage.googleapis.com:443
+            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout repository
         uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
       - name: Get version

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -94,15 +94,6 @@ jobs:
         with:
           cache: npm
           node-version-file: .nvmrc
-        # The 7 lines following this comment block, as well as the block itself,
-        # should be removed when the `.nvmrc` file is available at the `v0` ref.
-        if: ${{ matrix.ref != 'v0' }}
-      - if: ${{ matrix.ref == 'v0' }}
-        name: Install Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        with:
-          cache: npm
-          node-version: 20
       - name: Audit all npm dependencies
         if: ${{ !startsWith(matrix.ref, 'v') }}
         run: make audit-npm


### PR DESCRIPTION
Closes #307
Followup to #301
Relates to #348

## Summary

Addresses two issue in the CI following the release of [v0.4.5](https://github.com/ericcornelissen/js-regex-security-scanner/releases/tag/v0.4.5). First, this removes temporary logic from `reusable-audit.yml` that is no longer needed with the [`.nvmrc` file](https://github.com/ericcornelissen/js-regex-security-scanner/blob/0426d5b396c1768055fba680d0d9d340941fbe1a/.nvmrc) landing in a release. Second, this adds `tuf-repo-cdn.sigstore.dev:443` to the egress policy allowlist of the "Publish / Docker Hub" job to make sure that job can create a signature for the Docker image it publishes.