### PR TITLE
Refactor image licenses check script

### DIFF
--- a/scripts/check-licenses.js
+++ b/scripts/check-licenses.js
@@ -18,8 +18,6 @@ const projectRoot = path.resolve(
 	"..",
 );
 
-const matches = (string) => (regexp) => regexp.test(string);
-
 const quoted = (string) => `'${string}'`;
 
 const setEqual = (collection1, collection2) => {
@@ -30,15 +28,27 @@ const setEqual = (collection1, collection2) => {
 	);
 };
 
-const toMatchWholeWordExpression = (string) => {
-	const preWordExpr = /(?:^|[\s(])/.source;
-	const postWordExpr = /(?:[\s)]|$)/.source;
-	return new RegExp(`${preWordExpr}${string}${postWordExpr}`, "i");
+const wholeWordMatches = (str) => (substr) => {
+	substr = substr.toLowerCase();
+	str = str.toLowerCase();
+
+	const matchIndex = str.indexOf(substr);
+	if (matchIndex === -1) {
+		return false;
+	}
+
+	return (
+		// Start-of-string OR preceded by a space or similar ...
+		(matchIndex === 0 || [" ", "("].includes(str.charAt(matchIndex - 1))) &&
+		// ... AND end-of-string OR followed by a space or similar
+		(matchIndex + substr.length === str.length ||
+			[" ", ")"].includes(str.charAt(matchIndex + substr.length)))
+	);
 };
 
 const isAllowedLicense = (licenseInfo) => {
 	const license = licenseInfo.spdxExpression;
-	return allowedLicenses.map(toMatchWholeWordExpression).some(matches(license));
+	return allowedLicenses.some(wholeWordMatches(license));
 };
 
 const applyCorrection = (artifact) => {


### PR DESCRIPTION
Relates to #133, #218

## Summary

Refactor the script for checking image licenses with a new whole word match logic. The old logic was fine, but unfortunately relied on string interpolation into a Regular Expression which is not ideal - it's a potential attack vector (identified by Semgrep ([ref 1](https://github.com/ericcornelissen/js-regex-security-scanner/blob/c87b54106692c6564e9be021e1582004299bb0fc/.github/workflows/check.yml#L136-L155), [ref 2](https://semgrep.dev/))). Granted, there is no real attack vector here [^1], but I'm changing it primarily to avoid anyone looking at this code copying the vulnerable implementation - and partly to prove I can :)

[^1]: The first and last parts are declared just prior to the `RegExp` instantiation, the middle part always comes from `allowedLicenses` which is recorded elsewhere in the codebase (in `.licensee.json` to be specific).