### PR TITLE
Unignore CVE-2023-2650

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -6,9 +6,6 @@ file: vulns.json
 fail-on-severity: low
 
 ignore:
-  # Ignore because  this project isn't affected (no ASN.1 object ids used).
-  - vulnerability: CVE-2023-2650
-
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:
       type: npm


### PR DESCRIPTION
Relates to #347, #353

## Summary

Since the bump to Node.js 20.3.0 (#353) the CVE is no longer affecting the project so it should no longer be ignored, reverting #347.