### PR TITLE
Move Semgrep into separate workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -133,26 +133,6 @@ jobs:
       - name: Lint YAML
         if: ${{ failure() || success() }}
         run: make lint-yml
-  semgrep:
-    name: Semgrep
-    runs-on: ubuntu-22.04
-    if: ${{ github.actor != 'dependabot[bot]' }}
-    permissions:
-      security-events: write # To upload SARIF results
-    container:
-      image: returntocorp/semgrep
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - name: Perform Semgrep analysis
-        run: semgrep ci --sarif --output semgrep.sarif
-        env:
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
-      - name: Upload Semgrep report to GitHub
-        uses: github/codeql-action/upload-sarif@f6e388ebf0efc915c6c5b165b019ee61a6746a38 # v2.20.1
-        if: ${{ failure() || success() }}
-        with:
-          sarif_file: semgrep.sarif
   test:
     name: Test with ${{ matrix.engine }}
     runs-on: ubuntu-22.04

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,28 @@
+name: Semgrep
+on:
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-22.04
+    permissions:
+      security-events: write # To upload SARIF results
+    container:
+      image: returntocorp/semgrep
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Perform Semgrep analysis
+        run: semgrep ci --sarif --output semgrep.sarif
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+      - name: Upload Semgrep report to GitHub
+        uses: github/codeql-action/upload-sarif@f6e388ebf0efc915c6c5b165b019ee61a6746a38 # v2.20.1
+        if: ${{ failure() || success() }}
+        with:
+          sarif_file: semgrep.sarif


### PR DESCRIPTION
Relates to #218

## Summary

Separate the continuous Semgrep job from the general checks workflow. The motivation for this is that Semgrep requires access to a secret to work, and this secret isn't available on Pull Requests from forks. This leads in a failed pipeline for external contributors, which is not desired. Hence, just run it on `main` and address problems it finds separately.