### PR TITLE
Rename secrets for automation purposes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,8 +40,8 @@ jobs:
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
         id: automation-token
         with:
-          app_id: ${{ secrets.RELEASE_APP_ID }}
-          private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.AUTOMATION_ID }}
+          private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
       - name: Update tooling
         uses: ericcornelissen/tool-versions-update-action/pr@479c41ef190561c39ed9b0c1cb43c102084f1fc9 # v0.2.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,10 @@ jobs:
           node-version-file: .nvmrc
       - name: Create token to create Pull Request
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
-        id: pull_request_token
+        id: automation-token
         with:
-          app_id: ${{ secrets.RELEASE_APP_ID }}
-          private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.AUTOMATION_ID }}
+          private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
       - name: Bump version
         env:
           UPDATE_TYPE: ${{ github.event.inputs.update_type }}
@@ -55,7 +55,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:
-          token: ${{ steps.pull_request_token.outputs.token }}
+          token: ${{ steps.automation-token.outputs.token }}
           title: New ${{ github.event.inputs.update_type }} release for v0
           body: |
             _This Pull Request was created automatically_


### PR DESCRIPTION
Relates to #160, #178

## Summary

Rename `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` to `AUTOMATION_APP_ID` and `AUTOMATION_APP_PRIVATE_KEY` as these aren't used for release purposes exclusively.