### PR TITLE
Fix automated major version branch update logic

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
           script: |
             const ref = context.ref
             const tag = ref.replace(/^refs\/tags\//, "")
-            const major = tag.replace(/\.\d\.\d$/, "")
+            const major = tag.replace(/\.\d+\.\d+$/, "")
             return major
       - name: Update release branch
         run: git push origin 'HEAD:${{ steps.version.outputs.result }}'


### PR DESCRIPTION
Relates to https://github.com/ericcornelissen/js-regex-security-scanner/pull/405#issuecomment-1637636429

## Summary

Fixes the automated publish logic for version numbers with more than one minor or patch digit to correctly extract the major version in order to update the major version (branch/)ref.