### PR TITLE
Ignore CVE-2023-2975 and CVE-2023-3446

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -6,6 +6,12 @@ file: vulns.json
 fail-on-severity: low
 
 ignore:
+  # Ignore because this project isn't affected at runtime.
+  - vulnerability: CVE-2023-2975
+
+  # Ignore because this project isn't affected at runtime.
+  - vulnerability: CVE-2023-3446
+
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:
       type: npm


### PR DESCRIPTION
Supersedes #423
Relates to #325, #347

## Summary

Update the Grype configuration to ignore two OpenSSL CVEs that don't really effect this project. First, at runtime there is no networking happening so there the CVEs have no impact. Secondly, while these CVEs may have a theoretic impact at build time, it is not considered a problem.

The CVEs _should_ resolve over time as the base Docker image is upgraded.