### PR TITLE
Use environment for deployment to Docker hub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,9 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       id-token: write # To perform keyless signing with cosign
+    environment:
+      name: docker
+      url: https://hub.docker.com/r/ericornelissen/js-re-scan
     needs:
       - validate
     steps:


### PR DESCRIPTION
## Summary

Use an [environment for deployment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) in order to limit the scope of the Docker Hub secrets from all workflows to workflows with the right environment.

The environment has already been created, including appropriate secrets and configurations. The old secrets have also already been deleted (and the old API token has been revoked).