### PR TITLE
Ignore CVE-2023-4807

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -6,6 +6,9 @@ file: vulns.json
 fail-on-severity: low
 
 ignore:
+  # Ignore because this project isn't affected at runtime.
+  - vulnerability: CVE-2023-4807
+
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:
       type: npm


### PR DESCRIPTION
Relates to #325, #347, #424

## Summary

Update the Grype configuration to ignore one OpenSSL CVE that doesn't really effect this project. First, at runtime there is no networking happening so there the CVE has no impact. Secondly, while these CVE may have a theoretic impact at build time, it is not considered a problem.