### PR TITLE
Adopt SPDX license identifiers for file-level license details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Changelog
 
 All notable changes to the _JavaScript Regex Security Scanner_ will be

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Contributing Guidelines
 
 The _JavaScript Regex Security Scanner_ project welcomes contributions and

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
+
 # JavaScript Regex Security Scanner
 
 A static analyzer to scan JavaScript and TypeScript code for problematic regular

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Release Guidelines
 
 If you need to release a new version of the _JavaScript Regex Security Scanner_,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Security Policy
 
 The maintainers of the _JavaScript Regex Security Scanner_ project take security

--- a/scripts/bump-changelog.js
+++ b/scripts/bump-changelog.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as url from "node:url";

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as process from "node:process";

--- a/scripts/check-licenses.js
+++ b/scripts/check-licenses.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as process from "node:process";

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import cp from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";


### PR DESCRIPTION
Relates to #311

## Summary

Add SPDX license identifiers to relevant (non-configuration and non-testdata) files to indicate, at the file level, what license applies. This is partially useful for anyone that (somehow) only has access to part of the project, but in the case of some files it actually clarifies the intended license.

