### PR TITLE
Ignore CVE-2023-5678

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -9,6 +9,9 @@ ignore:
   # Ignore because this project isn't affected at runtime.
   - vulnerability: CVE-2023-5363
 
+  # Ignore because this project isn't affected at runtime.
+  - vulnerability: CVE-2023-5678
+
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:
       type: npm


### PR DESCRIPTION
Relates to #485, #524

## Summary

Update the Grype configuration to ignore one OpenSSL CVE that doesn't really effect this project. First, at runtime there is no networking happening so there the CVE has no impact. Secondly, while these CVE may have a theoretic impact at build time, it is not considered a problem.