### PR TITLE
Configure default assignee for bot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     open-pull-requests-limit: 1
+    assignees:
+      - ericcornelissen
     labels:
       - ci
       - dependencies
@@ -12,6 +14,8 @@ updates:
   - package-ecosystem: npm
     directory: /
     open-pull-requests-limit: 1
+    assignees:
+      - ericcornelissen
     labels:
       - dependencies
     schedule:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Update tooling
         uses: ericcornelissen/tool-versions-update-action/pr@80dab8d99cefefdcfcc6ad4adbb6bc7a07c39e7f # v0.3.7
         with:
+          assignees: ericcornelissen
           labels: dependencies
           max: 1
           token: ${{ steps.automation-token.outputs.token }}


### PR DESCRIPTION
## Summary

Configure Dependabot and [`ericcornelissen/tool-versions-update-action`](https://github.com/ericcornelissen/tool-versions-update-action) to automatically set the default assignee for Pull Request they generating. This is based on historical precedence [for Dependabot](https://github.com/ericcornelissen/js-regex-security-scanner/pulls?q=is%3Apr+author%3Aapp%2Fdependabot) and [for `ericcornelissen/tool-versions-update-action`](https://github.com/ericcornelissen/js-regex-security-scanner/pulls?q=is%3Apr+author%3Aapp%2Fec-automation-bot).

The configuration changes are based on the [Dependabot docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#assignees) and [`ericcornelissen/tool-versions-update-action` docs](https://github.com/ericcornelissen/tool-versions-update-action/tree/v0.3.7/pr#usage).