### PR TITLE
Ignore CVE-2023-4236(3|4|5|6)

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -12,6 +12,18 @@ ignore:
   # Ignore because this project isn't affected at runtime.
   - vulnerability: CVE-2023-5678
 
+  # Ignore because _printf_ isn't used.
+  - vulnerability: CVE-2023-42363
+
+  # Ignore because _awk_ isn't used.
+  - vulnerability: CVE-2023-42364
+
+  # Ignore because _awk_ isn't used.
+  - vulnerability: CVE-2023-42365
+
+  # Ignore because _awk_ isn't used.
+  - vulnerability: CVE-2023-42366
+
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:
       type: npm


### PR DESCRIPTION
Relates to #547

## Summary 
Ignore 4 CVEs (CVE-2023-42363, CVE-2023-42364, CVE-2023-42365, CVE-2023-42366) related to BusyBox because the vulnerable functionality isn't used by this project.