### PR TITLE
Change `DOCKER_USERNAME` from a secret to a variable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
+          username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push to Docker Hub
         id: docker_hub


### PR DESCRIPTION
Relates to #465

## Summary

Since the Docker username isn't a secret, it can be a [variable](https://docs.github.com/en/actions/learn-github-actions/variables) instead of a secret. This change is motivated by the following warning from recent runs of the `publish.yml` workflow:

> [!WARNING]
> Docker Hub
> Skip setting environment url as environment 'docker' may contain secret.

which I believe is because the URL (<https://hub.docker.com/r/ericornelissen/js-re-scan>) contains the (previously secret) username (`ericornelissen`).