### PR TITLE
Disable lifecycle scripts by default

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 engine-strict=true
+ignore-scripts=true
 lockfile-version=3
 save-exact=true


### PR DESCRIPTION
## Summary

Update the repository configuration to disable lifecycle scripts (such as installation scripts) by default. None of this project's current dependencies, nor this project itself, uses such scripts.