### PR TITLE
License supporting code more permissively

### DIFF
--- a/scripts/bump-changelog.js
+++ b/scripts/bump-changelog.js
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT-0
 
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT-0
 
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/scripts/check-licenses.js
+++ b/scripts/check-licenses.js
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT-0
 
 import * as fs from "node:fs";
 import * as path from "node:path";


### PR DESCRIPTION
Relates to #543

## Summary

Update the license used for supporting code to be more permissive, i.e. omitting the attribution requirement.