### PR TITLE
Use explicit registry in `Containerfile` base image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:20.10.0-alpine3.19
+FROM docker.io/node:20.10.0-alpine3.19
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
Relates to #539

## Summary

Improve compatibility of the `Containerfile` with non-Docker engines.