### PR TITLE
Make `Makefile` license explicit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT-0
+
 ENGINE?=docker
 TAG?=latest
 


### PR DESCRIPTION
Relates to #543, #598

## Summary

Add an explicit license to the `Makefile`.