### PR TITLE
Upgrade Node.js from 20.10.0 to 20.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning].
 ## [Unreleased]
 
 - (`2bfb28c`) Bump `@typescript-eslint/parser` from `6.13.2` to `6.16.0`.
+- (`ec7fc87`) Bump Node.js runtime from `20.10.0` to `20.11.0`.
 
 ## [0.4.17] - 2023-12-23
 

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:20.10.0-alpine3.19
+FROM docker.io/node:20.11.0-alpine3.19
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
# Summary

Upgrade Node.js to the latest available version of the latest (and currently used) stable release line.