### PR TITLE
Ignore CVE-2023-6129

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -18,6 +18,9 @@ ignore:
   # Ignore because _awk_ isn't used.
   - vulnerability: CVE-2023-42366
 
+  # Ignore because OpenSSL isn't used at runtime.
+  - vulnerability: CVE-2023-6129
+
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:
       type: npm


### PR DESCRIPTION
## Summary

Ignore CVE-2023-6129 related to OpenSSL because it's not used at runtime. Theoretically there is a chance this is exploitable at build time, but given that there's currently no update path available this risk is accepted.