### PR TITLE
Upgrade to the latest available Node.js v20 release

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -18,9 +18,6 @@ ignore:
   # Ignore because _awk_ isn't used.
   - vulnerability: CVE-2023-42366
 
-  # Ignore because OpenSSL isn't used at runtime.
-  - vulnerability: CVE-2023-6129
-
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:
       type: npm

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:20.11.0-alpine3.19
+FROM docker.io/node:20.11.1-alpine3.19
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
Relates to #619

## Summary

Upgrade the container to the latest available release in the v20 release line.

Correspondingly, remove a now-unnecessary ignore directive from the Grype configuration.