### PR TITLE
Redo alerts (i.e. notes and warnings) in the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ When you open a Pull Request that implements an issue make sure to link to that
 issue in the Pull Request description and explain how you implemented the issue
 as clearly as possible.
 
-> **Note** If you, for whatever reason, can no longer continue your contribution
+> **NOTE:** If you, for whatever reason, can not continue with your contribution
 > please share this in the issue or your Pull Request. This gives others the
 > opportunity to work on it. If we don't hear from you for an extended period of
 > time we may decide to allow others to work on the issue you were assigned to.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ JavaScript or TypeScript project. For example, to scan the current directory:
 docker run --rm -v $(pwd):/project docker.io/ericornelissen/js-re-scan:latest
 ```
 
-> **Note**: To use [Podman] instead of [Docker] you can replace `docker` by
+> **NOTE:** To use [Podman] instead of [Docker] you can replace `docker` by
 > `podman` in any example command.
 
 ### Ignore patterns

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -97,7 +97,7 @@ the automatic release process, follow these steps to release a new version
    git push origin v0.1.2
    ```
 
-   > **Note**: At this point, the continuous delivery automation may kick in and
+   > **NOTE:** At this point, the continuous delivery automation may kick in and
    > complete the release process. If not, or only partially, continue following
    > the remaining steps.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,7 +54,7 @@ Try to include as many of the following items as possible in a security report:
 
 ## Advisories
 
-> **Note**: Advisories will be created only for vulnerabilities present in
+> **NOTE:** Advisories will be created only for vulnerabilities present in
 > released versions of the project.
 
 | ID               | Date       | Affected versions | Patched versions |


### PR DESCRIPTION
Relates to #581

## Summary

Update the "alerts" present in the MarkDown documentation to move adopt a style that works independently of where it is rendered.
