### PR TITLE
Configure ShellCheck for `actionlint`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build
         env:
           ENGINE: ${{ matrix.engine }}
-        run: make build "ENGINE=$ENGINE"
+        run: make build "ENGINE=${ENGINE}"
   licenses:
     name: Licenses
     runs-on: ubuntu-22.04
@@ -174,4 +174,4 @@ jobs:
       - name: Test
         env:
           ENGINE: ${{ matrix.engine }}
-        run: make test "ENGINE=$ENGINE"
+        run: make test "ENGINE=${ENGINE}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Update release branch
         env:
           MAJOR_VERSION: ${{ steps.version.outputs.result }}
-        run: git push origin "HEAD:$MAJOR_VERSION"
+        run: git push origin "HEAD:${MAJOR_VERSION}"
   docker-hub:
     name: Docker Hub
     runs-on: ubuntu-22.04
@@ -86,7 +86,7 @@ jobs:
         id: versions
         run: |
           COSIGN_VERSION="$(grep cosign < .tool-versions | awk '{print $2}')"
-          echo "cosign=$COSIGN_VERSION" >> "$GITHUB_OUTPUT"
+          echo "cosign=${COSIGN_VERSION}" >> "${GITHUB_OUTPUT}"
       - name: Install cosign
         uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
         with:
@@ -114,10 +114,10 @@ jobs:
           WORKFLOW: ${{ github.workflow }}
         run: |
           cosign sign --yes \
-            -a "repo=$REPO" \
-            -a "workflow=$WORKFLOW" \
-            -a "ref=$REF" \
-            "docker.io/ericornelissen/js-re-scan@$IMAGE_DIGEST"
+            -a "repo=${REPO}" \
+            -a "workflow=${WORKFLOW}" \
+            -a "ref=${REF}" \
+            "docker.io/ericornelissen/js-re-scan@${IMAGE_DIGEST}"
   validate:
     name: Validate
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Bump version
         env:
           UPDATE_TYPE: ${{ github.event.inputs.update_type }}
-        run: node scripts/bump-version.js "$UPDATE_TYPE"
+        run: node scripts/bump-version.js "${UPDATE_TYPE}"
       - name: Update the changelog
         run: node scripts/bump-changelog.js
       - name: Create Pull Request

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -52,7 +52,7 @@ jobs:
         id: git
         run: |
           COMMIT_SHA="$(git rev-parse HEAD)"
-          echo "commit-sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
+          echo "commit-sha=${COMMIT_SHA}" >> "${GITHUB_OUTPUT}"
       - name: Audit dependencies in container image
         run: make audit-image
       - name: Upload SBOM and vulnerability scan

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,8 @@ license-check-npm: $(NODE_MODULES) ## Check npm dependency licenses
 lint: lint-ci lint-image lint-js lint-md lint-yml ## Lint the project
 
 lint-ci: $(TOOLING) ## Lint Continuous Integration configuration files
-	@actionlint
+	@SHELLCHECK_OPTS='--enable=avoid-nullary-conditions --enable=deprecate-which --enable=quote-safe-variables --enable=require-variable-braces' \
+		actionlint
 
 lint-image: $(TOOLING) ## Lint the Containerfile
 	@hadolint \


### PR DESCRIPTION
Relates to #662

## Summary

Configure ShellCheck when ran as part of `actionlint` following the description about it added in <https://github.com/rhysd/actionlint/releases/tag/v1.6.27>.