### PR TITLE
Upgrade to the latest available Node.js v20 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning].
 - (`27987f6`) Bump `@typescript-eslint/parser` from `7.1.0` to `7.2.0`.
 - (`fb57391`) Bump `@typescript-eslint/parser` from `7.2.0` to `7.5.0`.
 - (`e81c070`) Bump Node.js runtime from `20.11.1` to `20.12.0`.
+- (`55a49ed`) Bump Node.js runtime from `20.12.0` to `20.12.1`.
 
 ## [0.4.18] - 2024-02-17
 

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:20.12.0-alpine3.19
+FROM docker.io/node:20.12.1-alpine3.19
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
Relates to #690

## Summary

Upgrade the container to the latest available release in the v20 release line. This is a security patch, see: <https://nodejs.org/en/blog/vulnerability/april-2024-security-releases/>