### PR TITLE
Use `npm clean-install` in container image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -26,7 +26,7 @@ RUN mkdir /home/node/js-re-scan
 WORKDIR /home/node/js-re-scan
 
 COPY --chown=node:node package.json package-lock.json ./
-RUN npm install \
+RUN npm clean-install \
 	--omit=dev \
 	--no-audit \
 	--no-fund \


### PR DESCRIPTION
## Summary

Switch from `npm install`(/`npm i`) to `npm clean-install`(/`npm ci`) when building the container image to benefit from its behavior as described in [the `npm ci` docs](https://docs.npmjs.com/cli/v10/commands/npm-ci). In particular `npm ci` will:

- fail if the lockfile is missing, which can catch mistakes in the `Containerfile`;
- error if the manifest and lockfile are out of sync, which can help catch mistakes in the project state;
- override `node_modules/` in case it is accidentally included in the container at build time, improving reproducibility;
- not change the manifest or lockfile, thus also improving reproducibility.