### PR TITLE
Update transitive dependency `tar`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "js-regex-security-scanner",
       "dependencies": {
         "@typescript-eslint/parser": "7.5.0",
         "eslint": "8.57.0",
@@ -5204,9 +5205,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
-      "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",


### PR DESCRIPTION
Relates to [`Nightly / npm (main)` Job #595](https://github.com/ericcornelissen/js-regex-security-scanner/actions/runs/8625441108/job/23642046777#step:6:7)

## Summary

This update is related to CVE-2024-28863. Since `tar` is only used as a development dependency I will merge this but there won't be a release for it because end-users of the library aren't affected.