### PR TITLE
Upgrade to Node.js v22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning].
 - (`e81c070`) Bump Node.js runtime from `20.11.1` to `20.12.0`.
 - (`55a49ed`) Bump Node.js runtime from `20.12.0` to `20.12.1`.
 - (`8d03533`) Bump Node.js runtime from `20.12.1` to `20.12.2`.
+- (`dda546e`) Bump Node.js runtime from `20.12.2` to `22.1.0`.
 
 ## [0.4.18] - 2024-02-17
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-# Copyright 2023 Eric Cornelissen
+# Copyright 2024 Eric Cornelissen
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:20.12.2-alpine3.19
+FROM docker.io/node:22.1.0-alpine3.19
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
Relates to #707, #724

## Summary

This upgrades the runtime version of Node.js to the latest LTS version, namely v22. This upgrades immediately to the latest available release for that line.

See:
- <https://nodejs.org/en/blog/release/v22.0.0>
- <https://nodejs.org/en/blog/release/v22.1.0>