### PR TITLE
Bump Alpine from v3.19 to v3.20

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -6,17 +6,11 @@ file: vulns.json
 fail-on-severity: low
 
 ignore:
-  # Ignore because _printf_ isn't used.
-  - vulnerability: CVE-2023-42363
-
   # Ignore because _awk_ isn't used.
   - vulnerability: CVE-2023-42364
 
   # Ignore because _awk_ isn't used.
   - vulnerability: CVE-2023-42365
-
-  # Ignore because _awk_ isn't used.
-  - vulnerability: CVE-2023-42366
 
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning].
 - (`97aa650`) Bump `eslint-plugin-markdown` from `4.0.1` to `5.0.0`.
 - (`4aa5659`) Bump `eslint-plugin-regexp` from `2.3.0` to `2.6.0`.
 - (`66347f4`) Bump `@typescript-eslint/parser` from `7.7.1` to `7.10.0`.
+- (`323be03`) Bump Alpine from `3.19` to `3.20`.
 - (`7adf7c5`) Bump Node.js runtime from `22.1.0` to `22.2.0`.
 
 ## [0.4.19] - 2024-05-06

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:22.2.0-alpine3.19
+FROM docker.io/node:22.2.0-alpine3.20
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
Relates to #562, #591, #592

## Summary

Update the Node.js and Alpine versions in the scanner container.