### PR TITLE
Ignore for CVE-2024-5535

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -6,6 +6,9 @@ file: vulns.json
 fail-on-severity: low
 
 ignore:
+  # Ignore because no networking occurs at runtime.
+  - vulnerability: CVE-2024-5535
+
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:
       type: npm


### PR DESCRIPTION
## Summary

Update the Grype configuration to add an ignore directive for the CVE-2024-5535 vulnerability. This vulnerability affects OpenSSL and so is of little concern since no networking (or cryptography) should occur at runtime.