### PR TITLE
Bump Node.js version from 22.4.0 to 22.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`005e344`) Bump Node.js runtime from `22.3.0` to `22.4.0`.
+- (`3ade314`) Bump Node.js runtime from `22.4.0` to `22.4.1`.
 
 ## [0.4.21] - 2024-06-25
 

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:22.4.0-alpine3.20
+FROM docker.io/node:22.4.1-alpine3.20
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
Relates to #791

## Summary

See <https://nodejs.org/en/blog/release/v22.4.1>.