### PR TITLE
Use reusable workflows from current branch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ permissions: read-all
 jobs:
   audit:
     name: Audit
-    uses: ericcornelissen/js-regex-security-scanner/.github/workflows/reusable-audit.yml@main
+    uses: ./.github/workflows/reusable-audit.yml
     needs:
       - build
   build:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   audit:
     name: Audit
-    uses: ericcornelissen/js-regex-security-scanner/.github/workflows/reusable-audit.yml@main
+    uses: ./.github/workflows/reusable-audit.yml
     with:
       refs: |-
         ["main", "v0"]


### PR DESCRIPTION
## Summary

Always use reusable workflows from the current branch. Based on: <https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow>