### PR TITLE
Avoid creating identical images with different names

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ If you want you can build the scanner from scratch. From the root of this
 project run something like:
 
 ```shell
-docker build --file Containerfile --tag js-regex-scanner .
+docker build --file Containerfile .
 ```
 
 Or use the convenience [Make] target:


### PR DESCRIPTION
Relates to #658

## Summary

Update the example build in the README, which is ran as part of the tests (see `docs.test.js`), and resulted in the creation of two identical images with different names whenever `make test` (or similar) is run.