### PR TITLE
Bump Node.js runtime from `22.4.1` to `22.5.1`.

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -9,6 +9,10 @@ ignore:
   # Ignore because no networking occurs at runtime.
   - vulnerability: CVE-2024-5535
 
+  # Ignore because the permission model is not used.
+  - vulnerability: CVE-2024-22018
+  - vulnerability: CVE-2024-22020
+
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:
       type: npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning].
 
 - (`005e344`) Bump Node.js runtime from `22.3.0` to `22.4.0`.
 - (`3ade314`) Bump Node.js runtime from `22.4.0` to `22.4.1`.
+- (`9a8f130`) Bump Node.js runtime from `22.4.1` to `22.5.1`.
 
 ## [0.4.21] - 2024-06-25
 

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:22.4.1-alpine3.20
+FROM docker.io/node:22.5.1-alpine3.20
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
Relates to #796, ["Audit / Image" run #1568](https://github.com/ericcornelissen/js-regex-security-scanner/actions/runs/10056074315/job/27794150824)

## Summary

Bump the Node.js runtime used by the container from v22.4.1 to v22.5.1.