### PR TITLE
Bump Node.js runtime from `22.5.1` to `22.6.0`

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:22.5.1-alpine3.20
+FROM docker.io/node:22.6.0-alpine3.20
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
Relates to #811, #592

## Summary

Bump the Node.js runtime from `22.5.1` to `22.6.0`.