### PR TITLE
Bump Node.js runtime from `22.6.0` to `22.7.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning].
 - (`3ade314`) Bump Node.js runtime from `22.4.0` to `22.4.1`.
 - (`9a8f130`) Bump Node.js runtime from `22.4.1` to `22.5.1`.
 - (`f60dc81`) Bump Node.js runtime from `22.5.1` to `22.6.0`.
+- (`c60fc9e`) Bump Node.js runtime from `22.6.0` to `22.7.0`.
 
 ## [0.4.21] - 2024-06-25
 

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:22.6.0-alpine3.20
+FROM docker.io/node:22.7.0-alpine3.20
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
Relates to #592, #836

## Summary

Bump the Node.js runtime in the container from `22.6.0` to `22.7.0`.