### PR TITLE
Unignore CVE-2024-5535, CVE-2024-22018, and CVE-2024-22020

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -6,13 +6,6 @@ file: vulns.json
 fail-on-severity: low
 
 ignore:
-  # Ignore because no networking occurs at runtime.
-  - vulnerability: CVE-2024-5535
-
-  # Ignore because the permission model is not used.
-  - vulnerability: CVE-2024-22018
-  - vulnerability: CVE-2024-22020
-
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:
       type: npm


### PR DESCRIPTION
## Summary

These vulnerabilities are no longer detected following #840 and #836.