### PR TITLE
Ignore CVE-2024-6119

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -6,6 +6,9 @@ file: vulns.json
 fail-on-severity: low
 
 ignore:
+  - vulnerability: CVE-2024-6119
+    vex-justification: vulnerable_code_not_in_execute_path
+
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:
       type: npm


### PR DESCRIPTION
## Summary

Update the Grype configuration to ignore CVE-2024-6119. This vulnerability relates to certificate name checking, which does not happen at runtime for this project and is considered of minimal concern during builds.