### PR TITLE
Bump Node.js runtime from `22.8.0` to `22.9.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning].
 
 - (`5104754`) Bump ESLint from `9.9.1` to `9.10.0`
 - (`a9756a0`) Bump Node.js runtime from `22.7.0` to `22.8.0`.
+- (`b542e3c`) Bump Node.js runtime from `22.8.0` to `22.9.0`.
 
 ## [0.4.23] - 2024-08-28
 

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:22.8.0-alpine3.20
+FROM docker.io/node:22.9.0-alpine3.20
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
Relates to #592, a9756a0a7fd53a20634d15195cc1d4af493ac30f

## Summary

Bump the Node.js runtime in the container from `22.8.0` to `22.9.0`.