### PR TITLE
Use Ubuntu 24.04 for jobs with Podman

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
       - build
   build:
     name: Build with ${{ matrix.engine }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -137,7 +137,7 @@ jobs:
         run: make lint-yml
   test:
     name: Test with ${{ matrix.engine }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - build
     strategy:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,20 +24,6 @@ jobs:
           - docker
           - podman
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            auth.docker.io:443
-            github.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            production.cloudflare.docker.com:443
-            registry-1.docker.io:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       - name: Build
@@ -50,29 +36,6 @@ jobs:
     needs:
       - build
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            auth.docker.io:443
-            files.pythonhosted.org:443
-            fulcio.sigstore.dev:443
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            production.cloudflare.docker.com:443
-            pypi.org:443
-            registry-1.docker.io:443
-            registry.npmjs.org:443
-            rekor.sigstore.dev:443
-            sigstore-tuf-root.storage.googleapis.com:443
-            toolbox-data.anchore.io:443
-            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       - name: Install Node.js
@@ -92,25 +55,6 @@ jobs:
     name: Lint
     runs-on: ubuntu-24.04
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            files.pythonhosted.org:443
-            fulcio.sigstore.dev:443
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            pypi.org:443
-            registry.npmjs.org:443
-            rekor.sigstore.dev:443
-            sigstore-tuf-root.storage.googleapis.com:443
-            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       - name: Install Node.js
@@ -147,21 +91,6 @@ jobs:
           - docker
           - podman
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            auth.docker.io:443
-            github.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            production.cloudflare.docker.com:443
-            registry-1.docker.io:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,13 +11,6 @@ jobs:
       pull-requests: write # To assign labels
     runs-on: ubuntu-24.04
     steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
       - name: Set labels on Pull Request
         uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,22 +20,6 @@ jobs:
       contents: write # To push a commit
       pull-requests: write # To open a Pull Request
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            files.pythonhosted.org:443
-            fulcio.sigstore.dev:443
-            github.com:443
-            gitlab.com:443
-            objects.githubusercontent.com:443
-            pypi.org:443
-            rekor.sigstore.dev:443
-            sigstore-tuf-root.storage.googleapis.com:443
-            tuf-repo-cdn.sigstore.dev:443
       - name: Create automation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         id: automation-token

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,13 +15,6 @@ jobs:
     needs:
       - validate
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            github.com:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -51,26 +44,6 @@ jobs:
     needs:
       - validate
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            auth.docker.io:443
-            fulcio.sigstore.dev:443
-            github.com:443
-            index.docker.io:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            production.cloudflare.docker.com:443
-            raw.githubusercontent.com:443
-            registry-1.docker.io:443
-            registry.npmjs.org:443
-            rekor.sigstore.dev:443
-            sigstore-tuf-root.storage.googleapis.com:443
-            storage.googleapis.com:443
-            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       - name: Get version
@@ -122,29 +95,6 @@ jobs:
     name: Validate
     runs-on: ubuntu-24.04
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            auth.docker.io:443
-            artifactcache.actions.githubusercontent.com:443
-            files.pythonhosted.org:443
-            fulcio.sigstore.dev:443
-            github.com:443
-            gitlab.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            production.cloudflare.docker.com:443
-            pypi.org:443
-            registry-1.docker.io:443
-            registry.npmjs.org:443
-            rekor.sigstore.dev:443
-            sigstore-tuf-root.storage.googleapis.com:443
-            toolbox-data.anchore.io:443
-            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,18 +21,6 @@ jobs:
       contents: write # To push a commit
       pull-requests: write # To open a Pull Request
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            github.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       - name: Install Node.js

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -19,30 +19,6 @@ jobs:
       matrix:
         ref: ${{ fromJSON(inputs.refs) }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            auth.docker.io:443
-            files.pythonhosted.org:443
-            fulcio.sigstore.dev:443
-            github.com:443
-            gitlab.com:443
-            grype.anchore.io:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            production.cloudflare.docker.com:443
-            pypi.org:443
-            registry-1.docker.io:443
-            registry.npmjs.org:443
-            rekor.sigstore.dev:443
-            sigstore-tuf-root.storage.googleapis.com:443
-            toolbox-data.anchore.io:443
-            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         id: checkout
@@ -69,19 +45,6 @@ jobs:
       matrix:
         ref: ${{ fromJSON(inputs.refs) }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            ghcr.io:443
-            github.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            registry.npmjs.org:443
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -101,17 +64,6 @@ jobs:
     name: Secrets
     runs-on: ubuntu-24.04
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            actions-results-receiver-production.githubapp.com:80
-            api.github.com:443
-            artifactcache.actions.githubusercontent.com:443
-            github.com:443
-            objects.githubusercontent.com:443
       - name: Checkout Code
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:


### PR DESCRIPTION
Relates to #204, #741

## Summary

This is a followup to 4f88d3cc676de0072c3b3d66a9c0d7d8db005f35 to upgrade the remaining CI jobs (those involving Podman) to Ubuntu 24.04. These jobs encountered problems when upgrading initially, which were put aside to be able to upgrade most jobs asap with this as a followup.