### PR TITLE
Bump Node.js runtime from `22.9.0` to `22.10.0`

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -6,9 +6,6 @@ file: vulns.json
 fail-on-severity: low
 
 ignore:
-  - vulnerability: CVE-2024-6119
-    vex-justification: vulnerable_code_not_in_execute_path
-
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:
       type: npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning].
 
 - (`5da5a14`) Bump ESLint from `9.12.0` to `9.13.0`.
 - (`1f41d92`) Replace `eslint-plugin-markdown` by `@eslint/markdown`.
+- (`8292063`) Bump Node.js runtime from `22.9.0` to `22.10.0`.
 
 ## [0.4.25] - 2024-10-18
 

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:22.9.0-alpine3.20
+FROM docker.io/node:22.10.0-alpine3.20
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
Relates to #592, #856, #868

## Summary

Bump the Node.js runtime in the container from `22.9.0` to `22.10.0`.