### PR TITLE
Remove manual step from the release process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,41 @@
 name: Publish
 on:
   push:
-    tags:
-      - v*
+    branches:
+      - main
 
 permissions: read-all
 
 jobs:
-  branch:
-    name: Branch
+  check:
+    name: Check
     runs-on: ubuntu-24.04
+    outputs:
+      released: ${{ steps.version.outputs.released }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          fetch-depth: 0 # To fetch all tags
+      - name: Check released
+        id: version
+        run: |
+          VERSION="$(grep 'version=' < Containerfile | awk -F'"' '{print $2}')"
+          echo "version=v${VERSION}" >> "${GITHUB_OUTPUT}"
+          if [ -n "$(git tag --list "v${VERSION}")" ]; then
+            echo 'released=true' >> "${GITHUB_OUTPUT}"
+          else
+            echo 'released=false' >> "${GITHUB_OUTPUT}"
+          fi
+  git:
+    name: Git
+    runs-on: ubuntu-24.04
+    if: ${{ needs.check.outputs.released == 'false' }}
     permissions:
       contents: write # To push a branch
     needs:
-      - validate
+      - check
     steps:
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -22,39 +44,38 @@ jobs:
       - name: Get major version
         uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
         id: version
+        env:
+          VERSION: ${{ needs.check.outputs.version }}
         with:
           result-encoding: string
           script: |
-            const ref = context.ref
-            const tag = ref.replace(/^refs\/tags\//, "")
-            const major = tag.replace(/\.\d+\.\d+$/, "")
+            const version = `${process.env.VERSION}`
+            const major = version.replace(/\.\d\.\d$/, "")
             return major
-      - name: Update release branch
+      - name: Create release tag
+        env:
+          VERSION: ${{ needs.check.outputs.version }}
+        run: |
+          git tag "${VERSION}"
+          git push origin "${VERSION}"
+      - name: Update major version branch
         env:
           MAJOR_VERSION: ${{ steps.version.outputs.result }}
         run: git push origin "HEAD:${MAJOR_VERSION}"
   docker-hub:
     name: Docker Hub
     runs-on: ubuntu-24.04
+    if: ${{ needs.check.outputs.released == 'false' }}
     permissions:
       id-token: write # To perform keyless signing with cosign
     environment:
       name: docker
       url: https://hub.docker.com/r/ericornelissen/js-re-scan
     needs:
-      - validate
+      - check
     steps:
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-      - name: Get version
-        uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
-        id: version
-        with:
-          result-encoding: string
-          script: |
-            const ref = context.ref
-            const tag = ref.replace(/^refs\/tags\//, "")
-            return tag
       - name: Get cosign version
         id: versions
         run: |
@@ -78,7 +99,7 @@ jobs:
           push: true
           tags: >-
             ericornelissen/js-re-scan:latest,
-            ericornelissen/js-re-scan:${{ steps.version.outputs.result }}
+            ericornelissen/js-re-scan:${{ needs.check.outputs.version }}
       - name: Sign container image
         env:
           IMAGE_DIGEST: ${{ steps.docker_hub.outputs.digest }}
@@ -91,20 +112,3 @@ jobs:
             -a "workflow=${WORKFLOW}" \
             -a "ref=${REF}" \
             "docker.io/ericornelissen/js-re-scan@${IMAGE_DIGEST}"
-  validate:
-    name: Validate
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-        with:
-          submodules: true
-      - name: Install Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          cache: npm
-          node-version-file: .nvmrc
-      - name: Install tooling
-        uses: asdf-vm/actions/install@4f8f7939dd917fc656bb7c3575969a5988c28364 # v3.0.0
-      - name: Verify project validity
-        run: make verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,13 @@ jobs:
 
             ### Post-merge
 
-            Pull the `main` branch, create a git tag for the new release and push it.
+            _It will take a few minutes for this to happen._
 
+            - [ ] The new version is published to [Docker].
+            - [ ] A git tag for the new release is created.
+            - [ ] The major version branch is updated.
+
+            [docker]: https://hub.docker.com/r/ericornelissen/js-re-scan
             [semantic versioning]: https://semver.org/spec/v2.0.0.html
           branch: release-${{ github.event.inputs.update_type }}
           branch-suffix: random

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -79,6 +79,10 @@ the automatic release process, follow these steps to release a new version
 1. Merge the Pull Request if the changes look OK and all continuous integration
    checks are passing.
 
+   > **NOTE:** At this point, the continuous delivery automation may kick in and
+   > complete the release process. If not, or only partially, continue following
+   > the remaining steps.
+
 1. Immediately after the Pull Request is merged, sync the `main` branch:
 
    ```shell
@@ -97,10 +101,6 @@ the automatic release process, follow these steps to release a new version
    ```shell
    git push origin v0.1.2
    ```
-
-   > **NOTE:** At this point, the continuous delivery automation may kick in and
-   > complete the release process. If not, or only partially, continue following
-   > the remaining steps.
 
 1. Update the `v0` branch to point to the same commit as the new tag:
 


### PR DESCRIPTION
Closes #916

## Summary

Update the `publish.yml` workflow to trigger on commits on `main` and automatically publish a release whenever it detects the version number in the `Containerfile` does not have a corresponding git tag. Update the Release Guidelines and release PR description accordingly.