### PR TITLE
Ignore CVE-2024-9143

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -6,6 +6,9 @@ file: vulns.json
 fail-on-severity: low
 
 ignore:
+  - vulnerability: CVE-2024-9143
+    vex-justification: vulnerable_code_not_in_execute_path
+
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:
       type: npm


### PR DESCRIPTION
Relates to https://github.com/ericcornelissen/js-regex-security-scanner/actions/runs/11761775030

## Summary

Update the Grype configuration to ignore CVE-2024-9143. This vulnerability relates to elliptic curve cryptography, which is not used at runtime for this project and is considered of minimal concern during builds.