### PR TITLE
Relax `engines.node` specified in the manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "private": true,
   "engines": {
-    "node": ">=22.0.0",
+    "node": ">=18.20.5",
     "npm": ">=8.1.2"
   },
   "dependencies": {


### PR DESCRIPTION
Relates to #283, #730

## Summary

Update the minimum Node.js version as specified by the engines field in the package manifest. This resets is based on to the value of the project's initial commit (`>=18`) and current restrictions of this project (`>=18.20.5` for `node:test`) and its runtime dependencies (`>=18.18.0`).

Given this project is only ever supposed to "run" in a container, at this point I don't feel it's necessary to update the CI to test against the older versions of Node.js.