### PR TITLE
Correct major version logic for pushing major version branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
           result-encoding: string
           script: |
             const version = `${process.env.VERSION}`
-            const major = version.replace(/\.\d\.\d$/, "")
+            const major = version.replace(/\.\d+\.\d+$/, "")
             return major
       - name: Create release tag
         env:


### PR DESCRIPTION
Closes #944
Relates to #920

## Summary

The missing `+`s caused the logic to fail when the minor or patch number is greater than 9.