### PR TITLE
Bump Node.js from 22.10.0 to 22.12.0

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:22.10.0-alpine3.20
+FROM docker.io/node:22.12.0-alpine3.20
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
Relates to #592, #912

## Summary

Bump the Node.js runtime in the container from `22.10.0` to `22.12.0`.