### PR TITLE
Remove secrets check from CI

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -82,16 +82,3 @@ jobs:
       - name: Audit production npm dependencies
         if: ${{ startsWith(matrix.ref, 'v') }}
         run: make audit-npm ARGS="--omit dev"
-  secrets:
-    name: Secrets
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-        with:
-          fetch-depth: 0 # To allow for historic scans
-          persist-credentials: false
-      - name: Scan for secrets
-        uses: trufflesecurity/trufflehog@4d355d414e2d6c674bcebfe40cb648e22f6457ae # v3.83.1
-        with:
-          extra_args: --only-verified


### PR DESCRIPTION
## Summary

Update the CI to omit the job that checks for secrets and instead rely solely on GitHub for secret scanning in a continuous fashion. Individual contributors can still continue to use any secret scanning software they like locally.

The motivation for this removal is to reduce the supply chain surface by omitting unnecessary dependencies, given that this dependencies adds limited value.