### PR TITLE
Enable custom configuration for release auditing

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -58,7 +58,11 @@ jobs:
           GRYPERC: ${{ vars.GRYPERC }}
         run: echo "${GRYPERC}" | tee .grype.yml
       - name: Audit dependencies in container image
+        if: ${{ !startsWith(matrix.ref, 'v') }}
         run: make audit-vulnerabilities-image
+      - name: Audit dependencies in container image
+        if: ${{ startsWith(matrix.ref, 'v') }}
+        run: make audit-image
       - name: Upload SBOM and vulnerability scan
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         if: ${{ failure() || success() }}
@@ -91,4 +95,4 @@ jobs:
         run: make audit-vulnerabilities-npm
       - name: Audit production npm dependencies
         if: ${{ startsWith(matrix.ref, 'v') }}
-        run: make audit-vulnerabilities-npm ARGS="--omit dev"
+        run: make audit-npm ARGS="--omit dev"

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           cache: npm
           node-version-file: .nvmrc
+      - name: Insert custom configuration
+        if: ${{ startsWith(matrix.ref, 'v') }}
+        env:
+          NDMRC: ${{ vars.NDMRC }}
+        run: echo "${NDMRC}" | tee .ndmrc
       - name: Audit deprecation warnings
         run: make audit-deprecations
   image:
@@ -47,6 +52,11 @@ jobs:
           ref: ${{ matrix.ref }}
       - name: Install tooling
         uses: asdf-vm/actions/install@4f8f7939dd917fc656bb7c3575969a5988c28364 # v3.0.0
+      - name: Insert custom configuration
+        if: ${{ startsWith(matrix.ref, 'v') }}
+        env:
+          GRYPERC: ${{ vars.GRYPERC }}
+        run: echo "${GRYPERC}" | tee .grype.yml
       - name: Audit dependencies in container image
         run: make audit-vulnerabilities-image
       - name: Upload SBOM and vulnerability scan


### PR DESCRIPTION
Relates to https://github.com/ericcornelissen/depreman/issues/50

## Summary

Update the "Audit / Deprecations" and "Audit / Image" jobs to expect a custom configuration from the repository variables when they're running for a past release. This enables retroactively adjusting the config as necessarily, in particular allowing to ignore false positives.