### PR TITLE
Enable Docker updates for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,14 @@
 
 version: 2
 updates:
+  - package-ecosystem: docker
+    directory: /
+    open-pull-requests-limit: 1
+    labels:
+      - dependencies
+    schedule:
+      interval: daily
+      time: "05:00"
   - package-ecosystem: github-actions
     directory: /
     open-pull-requests-limit: 1


### PR DESCRIPTION
Closes #592

## Summary

Support for `Containerfile`s has been added in v0.291.0 of the Dependabot core, see:
https://github.com/dependabot/dependabot-core/releases/tag/v0.291.0