### PR TITLE
Bump Node.js runtime from `22.12.0` to `22.13.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning].
 - (`3066fe2`) Bump ESLint from `9.16.0` to `9.17.0`.
 - (`07844c2`) Bump ESLint from `9.17.0` to `9.18.0`.
 - (`65ea189`) Bump Node.js runtime from `22.10.0` to `22.12.0`.
+- (`bf42676`) Bump Node.js runtime from `22.12.0` to `22.13.0`.
 - (`48d3bfd`) Bump `@typescript-eslint/parser` from `8.16.0` to `8.18.1`.
 - (`c05e1cb`) Bump `@typescript-eslint/parser` from `8.18.1` to `8.20.0`.
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 Eric Cornelissen
+# Copyright 2022-2025 Eric Cornelissen
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:22.12.0-alpine3.21
+FROM docker.io/node:22.13.0-alpine3.21
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
Relates to #961, #978

## Summary

Bump the Node.js runtime in the container from `22.12.0` to `22.13.0`.