### PR TITLE
Bump Node.js from 22.13.0 to 22.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`613a51a`) Bump Node.js runtime from `22.13.0` to `22.13.1`.
 
 ## [0.4.30] - 2025-01-19
 

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:22.13.0-alpine3.21
+FROM docker.io/node:22.13.1-alpine3.21
 
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
Relates to https://github.com/ericcornelissen/js-regex-security-scanner/actions/runs/12961335492