### PR TITLE
Ignore known vulnerabilities in container image

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -39,7 +39,7 @@ jobs:
         run: make audit-deprecations-npm
       - name: Audit production deprecation warnings
         if: ${{ startsWith(matrix.ref, 'v') }}
-        run: make audit-deprecations-npm ARGS="--omit dev"
+        run: make audit-deprecations-npm ARGS="--omit=dev"
   image:
     name: Image
     runs-on: ubuntu-24.04

--- a/.grype.yml
+++ b/.grype.yml
@@ -6,6 +6,13 @@ file: vulns.json
 fail-on-severity: low
 
 ignore:
+  - vulnerability: CVE-2024-13176
+    vex-justification: vulnerable_code_not_in_execute_path
+  - vulnerability: CVE-2025-23083
+    vex-justification: vulnerable_code_not_in_execute_path
+  - vulnerability: CVE-2025-23090
+    vex-justification: vulnerable_code_not_in_execute_path
+
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:
       type: npm

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ audit: audit-deprecations audit-vulnerabilities ## Audit the project dependencie
 audit-deprecations: audit-deprecations-npm ## Audit deprecation warnings
 
 audit-deprecations-npm: $(NODE_MODULES) ## Audit the npm dependencies deprecation warnings
-	npx depreman \
+	@npx depreman \
 		--errors-only \
 		--report-unused \
 		$(ARGS)


### PR DESCRIPTION
Relates to #1005, #1010

## Summary

Ignore three vulnerabilities detected by Grype that don't affect this project.

`CVE-2024-13176` is related to cryptography, which is not used at runtime. `CVE-2025-23083` and `CVE-2025-23090` are related to the Node permission system, which we don't use at all.

Also snuk in two corrections for auditing deprecation warnings. 1 is to hide the audit command in make and 1 is to correctly omit warnings from development dependencies (`depreman` does not support the previous syntax).