### PR TITLE
Add `org.opencontainers.image.source` label to container

### DIFF
--- a/.hadolint.yml
+++ b/.hadolint.yml
@@ -14,6 +14,7 @@ label-schema:
   description: text
   license: spdx
   name: text
+  org.opencontainers.image.source: url
   version: semver
 strict-labels: true
 

--- a/Containerfile
+++ b/Containerfile
@@ -17,7 +17,8 @@ FROM docker.io/node:22.14.0-alpine3.21
 LABEL name="js-regex-security-scanner" \
 	description="A static analyzer to scan JavaScript code for problematic regular expressions." \
 	version="0.4.31" \
-	license="Apache-2.0"
+	license="Apache-2.0" \
+	org.opencontainers.image.source="https://github.com/ericcornelissen/js-regex-security-scanner"
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
## Summary

Update the container labels to include `org.opencontainers.image.source` which links to the original source repository. I added after seeing a notice about it on GHCR (as documented [here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)).