### PR TITLE
Trigger dev auditing based on the `Check` workflow

### DIFF
--- a/.github/workflows/audit-dev.yml
+++ b/.github/workflows/audit-dev.yml
@@ -1,20 +1,13 @@
 name: Audit
 on:
-  pull_request:
-    paths:
-      - .github/workflows/audit-dev.yml
-      - .grype.yml
-      - .ndmrc
-      - .syft.yml
-      - .tool-versions
-      - Containerfile
-      - package-lock.json
-  push:
-    branches:
-      - main
   schedule:
     - cron: 0 3 * * *
   workflow_dispatch: ~
+  workflow_run:
+    workflows:
+      - Check
+    types:
+      - completed
 
 permissions: read-all
 
@@ -37,6 +30,7 @@ jobs:
   image:
     name: Image
     runs-on: ubuntu-24.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0


### PR DESCRIPTION
Relates to #1046

## Summary

Change the triggers of `audit-dev.yml` from pushes and pull requests to instead depend on the "Check" workflow (`check.yml`). This is because the auditing can only succeed if the project can be build, so this dependency ensures these jobs are only run if the build has been checked. This comes at the cost of the path filters, meaning the auditing may now occur when no relevant files have changed.