### PR TITLE
New patch release for v0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Versioning].
 
 ## [Unreleased]
 
+- _No changes yet_
+
+## [0.4.34] - 2025-04-19
+
 - (`43ba04b`) Bump ESLint from `9.23.0` to `9.24.0`.
 - (`563ff65`) Bump `@eslint/markdown` from `6.3.0` to `6.4.0`.
 - (`ef8b7cd`) Bump `@typescript-eslint/parser` from `8.28.0` to `8.29.0`.

--- a/Containerfile
+++ b/Containerfile
@@ -16,7 +16,7 @@ FROM docker.io/node:22.14.0-alpine3.21
 
 LABEL org.opencontainers.image.title="js-regex-security-scanner" \
 	org.opencontainers.image.description="A static analyzer to scan JavaScript code for problematic regular expressions." \
-	org.opencontainers.image.version="0.4.33" \
+	org.opencontainers.image.version="0.4.34" \
 	org.opencontainers.image.licenses="Apache-2.0" \
 	org.opencontainers.image.source="https://github.com/ericcornelissen/js-regex-security-scanner"
 

--- a/scripts/bump-changelog.js
+++ b/scripts/bump-changelog.js
@@ -33,7 +33,7 @@ const changelogRaw = fs.readFileSync(changelogFilePath).toString();
 const versionLabel = containerfileRaw
 	.split(/\n/)
 	.map((line) => line.trim())
-	.find((line) => line.startsWith("version="));
+	.find((line) => line.startsWith("org.opencontainers.image.version="));
 const version = versionLabel.split('"')[1];
 
 // ----------


### PR DESCRIPTION
Relates to #1069, #1076, ["Release" workflow run #42](https://github.com/ericcornelissen/js-regex-security-scanner/actions/runs/14550222699)