### PR TITLE
Update the publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,10 +72,10 @@ jobs:
       matrix:
         include:
           - name: docker
-            image: ericornelissen/js-re-scan
+            image: docker.io/ericornelissen/js-re-scan
             url: https://hub.docker.com/r/ericornelissen/js-re-scan
           - name: ghcr
-            image: ericcornelissen/js-re-scan
+            image: ghcr.io/ericcornelissen/js-re-scan
             url: https://github.com/ericcornelissen/js-regex-security-scanner/pkgs/container/js-re-scan
     permissions:
       id-token: write # To perform keyless signing with cosign


### PR DESCRIPTION
Relates to #1049, #1054, #1055, #1081, ["Publish" workflow run #138](https://github.com/ericcornelissen/js-regex-security-scanner/actions/runs/14550260038)

## Summary

Include registry in image name to publish so that docker "knows" where to push to, it seems 0.4.34 could not be published to GHCR automatically because the workflow was trying to push it to Docker Hub without credentials.