### PR TITLE
Bump Node.js from 22.14.0 to 22.15.0

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -6,6 +6,11 @@ file: vulns.json
 fail-on-severity: low
 
 ignore:
+  - vulnerability: CVE-2024-58251
+    vex-justification: vulnerable_code_not_in_execute_path
+  - vulnerability: CVE-2025-46394
+    vex-justification: vulnerable_code_not_in_execute_path
+
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.
   - package:
       type: npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning].
 ## [Unreleased]
 
 - (`c5f441b`) Bump ESLint from `9.24.0` to `9.25.0`.
+- (`487a667`) Bump Node.js runtime from `22.14.0` to `22.15.0`.
 - (`68e830b`) Bump `@typescript-eslint/parser` from `8.30.1` to `8.31.0`.
 
 ## [0.4.34] - 2025-04-19

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:22.14.0-alpine3.21
+FROM docker.io/node:22.15.0-alpine3.21
 
 LABEL org.opencontainers.image.title="js-regex-security-scanner" \
 	org.opencontainers.image.description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
## Summary

Upgrade the version of Node.js of the base image for the container. The ignored vulnerabilities affect both the old and the new version.