### PR TITLE
Bump Node.js runtime from `22.15.0` to `24.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`c833dd2`) Bump Node.js runtime from `22.15.0` to `24.0.0`.
 
 ## [0.4.35] - 2025-05-06
 

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:22.15.0-alpine3.21
+FROM docker.io/node:24.0.0-alpine3.21
 
 LABEL org.opencontainers.image.title="js-regex-security-scanner" \
 	org.opencontainers.image.description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
Closes #1098