### PR TITLE
Bump Node.js from 24.0.2 to 24.1.0

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -8,10 +8,6 @@ fail-on-severity: low
 ignore:
   - vulnerability: CVE-2024-58251
     vex-justification: vulnerable_code_not_in_execute_path
-  - vulnerability: CVE-2025-23165
-    vex-justification: vulnerable_code_not_in_execute_path
-  - vulnerability: CVE-2025-23166
-    vex-justification: vulnerable_code_not_present
   - vulnerability: CVE-2025-46394
     vex-justification: vulnerable_code_not_in_execute_path
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- (`960f647`) Bump Node.js runtime from `24.0.2` to `24.1.0`.
 
 ## [0.4.36] - 2025-05-22
 

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/node:24.0.2-alpine3.21
+FROM docker.io/node:24.1.0-alpine3.21
 
 LABEL org.opencontainers.image.title="js-regex-security-scanner" \
 	org.opencontainers.image.description="A static analyzer to scan JavaScript code for problematic regular expressions." \


### PR DESCRIPTION
## Summary

Upgrade the Node.js version used at runtime and remove vulnerability ignore directives resolved in this release of Node.js.