### PR TITLE
Set up automated GitHub Release creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,15 @@ jobs:
         env:
           MAJOR_VERSION: ${{ steps.version.outputs.result }}
         run: git push origin "HEAD:${MAJOR_VERSION}"
+      - name: Create GitHub Release
+        env:
+          VERSION: ${{ needs.check.outputs.version }}
+        run: |
+          gh release create "${VERSION}" \
+            --title "Release ${VERSION}" \
+            --notes "Release ${VERSION}" \
+            --verify-tag=true \
+            --latest=true
   docker:
     name: Docker Hub
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Closes #1230

## Summary

Set up GitHub Release creation leveraging the by-default installed `gh` CLI in GitHub Actions. Creating a release on GitHub enables the use of immutable release which helps as a defense in depth strategy against supply chain attacks (even if users are unlikely to use the git tags for this project).