### PR TITLE
Add tool `dockle`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,6 +2,7 @@
 actionlint 1.7.7
 cosign 2.6.0
 diffoci 0.1.7
+dockle 0.4.15
 grype 0.99.0
 hadolint 2.14.0
 shellcheck 0.11.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,7 @@ To be able to contribute you need at least the following:
 - (Recommended) a code editor with [EditorConfig] support;
 - (Optional) [actionlint] (see `.tool-versions` for preferred version);
 - (Optional) [diffoci] (see `.tool-versions` for preferred version);
+- (Optional) [Dockle] (see `.tool-versions` for preferred version);
 - (Optional) [Grype] (see `.tool-versions` for preferred version);
 - (Optional) [hadolint] (see `.tool-versions` for preferred version);
 - (Optional) [ShellCheck] (see `.tool-versions` for preferred version);
@@ -280,6 +281,7 @@ exceptions defined in the `.ndmrc` file.
 [depreman]: https://github.com/ericcornelissen/depreman
 [diffoci]: https://github.com/reproducible-containers/diffoci
 [docker]: https://www.docker.com/
+[dockle]: https://github.com/goodwithtech/dockle
 [editorconfig]: https://editorconfig.org/
 [eslint]: https://eslint.org/
 [feature request]: https://github.com/ericcornelissen/js-regex-security-scanner/issues/new?labels=enhancement

--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,13 @@ check-formatting-md: $(NODE_MODULES) ## Check the formatting of MarkDown files
 		\
 		./*.md
 
-check-image: $(TOOLING) ## Check the Containerfile
+check-image: $(TOOLING) build ## Check the Containerfile
 	@hadolint \
 		Containerfile
+	@dockle \
+		--exit-code 1 --exit-level info \
+		--ignore CIS-DI-0005 --ignore CIS-DI-0006 --ignore DKL-DI-0006 \
+		$(IMAGE_NAME)
 
 check-licenses: check-licenses-image check-licenses-npm ## Check the dependency licenses
 


### PR DESCRIPTION
Relates to #67

## Summary

Add [`dockle`](https://github.com/goodwithtech/dockle) as a tool dependency to scan and validate the js-re-scan image.

Three rules are disabled:
- `CIS-DI-0005`: we use [cosign](https://github.com/sigstore/cosign)/[sigstore](https://www.sigstore.dev/) instead.
- `CIS-DI-0006`: a `HEALTHCHECK` is unnecessary for a CLI application.
- `DKL-DI-0006`: we have versioned tags.