### PR TITLE
Bump `cosign` from v2.6.1 to 3.0.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
           COSIGN_VERSION="$(grep cosign < .tool-versions | awk '{print $2}')"
           echo "cosign=${COSIGN_VERSION}" >>"${GITHUB_OUTPUT}"
       - name: Install cosign
-        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
           cosign-release: v${{ steps.versions.outputs.cosign }}
       - name: Install Docker Buildx
@@ -148,7 +148,7 @@ jobs:
           COSIGN_VERSION="$(grep cosign < .tool-versions | awk '{print $2}')"
           echo "cosign=${COSIGN_VERSION}" >>"${GITHUB_OUTPUT}"
       - name: Install cosign
-        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
           cosign-release: v${{ steps.versions.outputs.cosign }}
       - name: Install Docker Buildx

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 # Configuration file for asdf (https://asdf-vm.com/)
 actionlint 1.7.8
-cosign 2.6.1
+cosign 3.0.2
 diffoci 0.1.7
 dockle 0.4.15
 grype 0.99.0


### PR DESCRIPTION
Relates to #1266, https://github.com/ericcornelissen/js-regex-security-scanner/pull/1269#issuecomment-3394112754, #1271, https://github.com/sigstore/cosign-installer/issues/202
Supersedes #1274

## Summary

Bump `cosign` from v2.6.1 to v3.0.2 and the `sigstore/cosign-installer` action from v3.9.2 to v4.0.0 to be able install the new version of `cosign` in CI.
