### PR TITLE
Restore `ericcornelissen/tool-versions-update-action`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
-      "matchManagers": ["asdf", "nvm"],
+      "matchManagers": ["nvm"],
       "addLabels": ["meta"],
       "schedule": "* 0-4 * * 5",
       "prConcurrentLimit": 1

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -1,0 +1,40 @@
+name: Tooling
+on:
+  schedule:
+    - cron: 0 3 * * *
+  workflow_dispatch: ~
+
+permissions: read-all
+
+jobs:
+  update:
+    name: Update
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write # To push a commit
+      pull-requests: write # To open a Pull Request
+    steps:
+      - name: Create token to create Pull Request
+        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
+        id: automation-token
+        with:
+          app-id: ${{ secrets.AUTOMATION_ID }}
+          private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
+      - name: Update tooling
+        uses: ericcornelissen/tool-versions-update-action/pr@aa1815a7caf1aecd37208e34ad57bec973bcd507 # v2.2.1
+        with:
+          commit-message: Bump {{updated-tools}} from {{updated-old-versions}} to {{updated-new-versions}}
+          labels: dependencies
+          max: 1
+          pr-body: |
+            Bumps {{updated-tools}} from {{updated-old-versions}} to {{updated-new-versions}}.
+
+            ---
+
+            _This Pull Request was created using the [tool-versions-update-action]_
+
+            [tool-versions-update-action]: https://github.com/ericcornelissen/tool-versions-update-action
+          pr-title: Bump {{updated-tools}} from {{updated-old-versions}} to {{updated-new-versions}}
+          plugins: |
+            diffoci https://github.com/ericcornelissen/asdf-diffoci
+          token: ${{ steps.automation-token.outputs.token }}


### PR DESCRIPTION
Relates to #1215

## Summary

Disable `.tool-versions` updates by Renovate and re-setup [`ericcornelissen/tool-versions-update-action`](https://github.com/marketplace/actions/tool-versions-update-action) for this task instead because, frankly, it works way better.

From the Renovate UI it seems it is not able to figure out how to deal with `diffoci`, `dockle`, `grype`, nor `syft`:

<img width="1815" height="1008" src="https://github.com/user-attachments/assets/732307a0-0838-482d-8b78-401254bcb121" />
