### PR TITLE
Set `min-release-age` for npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,5 +4,6 @@ allow-git=none
 engine-strict=true
 ignore-scripts=true
 lockfile-version=3
+min-release-age=2
 prefer-dedupe=true
 save-exact=true


### PR DESCRIPTION
Relates to #1391, https://github.com/ericcornelissen/shescape/pull/2374

## Summary

This adds the `min-release-age` to .npmrc so that using npm on this project respects it and only installs packages released 2 or more days ago. Note that this option requires npm at least v11.10.0.