### PR TITLE
Update `.grype.yml`

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -10,9 +10,21 @@ ignore:
     vex-justification: vulnerable_code_not_in_execute_path
   - vulnerability: CVE-2026-2673
     vex-justification: vulnerable_code_not_in_execute_path
+  - vulnerability: CVE-2026-6042
+    vex-justification: vulnerable_code_not_in_execute_path
   - vulnerability: CVE-2026-27171
     vex-justification: vulnerable_code_not_in_execute_path
+  - vulnerability: CVE-2026-28387
+    vex-justification: vulnerable_code_not_in_execute_path
+  - vulnerability: CVE-2026-28388
+    vex-justification: vulnerable_code_not_in_execute_path
+  - vulnerability: CVE-2026-28389
+    vex-justification: vulnerable_code_not_in_execute_path
+  - vulnerability: CVE-2026-28390
+    vex-justification: vulnerable_code_not_in_execute_path
   - vulnerability: CVE-2026-31790
+    vex-justification: vulnerable_code_not_in_execute_path
+  - vulnerability: CVE-2026-40200
     vex-justification: vulnerable_code_not_in_execute_path
 
   # Ignore all npm vulnerabilities. This project relies on `npm audit` instead.


### PR DESCRIPTION
Relates to [Audit job #1175](https://github.com/ericcornelissen/js-regex-security-scanner/actions/runs/24299424244), [Audit Release job #406](https://github.com/ericcornelissen/js-regex-security-scanner/actions/runs/24299529011)

## Summary

CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390: OpenSSL, not used at runtime.

CVE-2026-6042, CVE-2026-40200: musl, not used at runtime.