### PR TITLE
Create workflow to update the `CHANGELOG.md`

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,68 @@
+name: Changelog
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions: read-all
+
+jobs:
+  add-to-changelog:
+    name: Add specific commit
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write # To push a commit
+    if: |
+      github.event.issue.pull_request &&
+      github.event.comment.user.login == 'ericcornelissen' &&
+      startsWith(github.event.comment.body, '/changelog ')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # To fetch all commits
+          persist-credentials: false
+          ref: refs/pull/${{ github.event.issue.number }}/head
+      - name: Create token to push commit
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: automation-token
+        with:
+          client-id: ${{ secrets.AUTOMATION_ID }}
+          private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
+      - name: Parse comment
+        id: comment
+        env:
+          COMMENT: ${{ github.event.comment.body }}
+        run: |
+          COMMIT=$(echo "${COMMENT}" | awk '{print $2}' | cut -c1-7)
+          echo "commit=${COMMIT}" >>"${GITHUB_OUTPUT}"
+      - name: Determine branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ steps.automation-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          BRANCH=$(gh pr view "${PR_NUMBER}" --json headRefName --jq '.headRefName')
+          echo "branch=${BRANCH}" >>"${GITHUB_OUTPUT}"
+      - name: Update the CHANGELOG.md
+        env:
+          COMMIT: ${{ steps.comment.outputs.commit }}
+        run: |
+          DESCRIPTION=$(git show "${COMMIT}" --format='%s' --no-patch)
+          LINE=$(echo "- (\`${COMMIT}\`) ${DESCRIPTION}.")
+          sed -i '/## \[Unreleased\]/{n; a '"${LINE}"'
+          }' CHANGELOG.md
+      - name: Create commit
+        env:
+          BRANCH: ${{ steps.pr.outputs.branch }}
+          GH_TOKEN: ${{ steps.automation-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          git remote set-url 'origin' "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}"
+
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+          git add 'CHANGELOG.md'
+          git commit --message 'Update the CHANGELOG.md'
+          git push 'origin' "HEAD:${BRANCH}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,11 +23,11 @@ jobs:
         id: version
         run: |
           VERSION="$(grep 'version=' < Containerfile | awk -F'"' '{print $2}')"
-          echo "version=v${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "version=v${VERSION}" >>"${GITHUB_OUTPUT}"
           if [ -n "$(git tag --list "v${VERSION}")" ]; then
-            echo 'released=true' >> "${GITHUB_OUTPUT}"
+            echo 'released=true' >>"${GITHUB_OUTPUT}"
           else
-            echo 'released=false' >> "${GITHUB_OUTPUT}"
+            echo 'released=false' >>"${GITHUB_OUTPUT}"
           fi
   git:
     name: Git


### PR DESCRIPTION
## Summary

Create a new workflow that is trigger on Pull Requests comments by me starting with `/changelog ` which takes as argument a commit SHA and will add the commit as a change to the CHANGELOG and push that to the Pull Request branch.

The main reason for this is to streamline Renovate PRs that update a runtime dependency, which should be listed in the changelog. Typing the comment is hopefully quicker than manually updating the `CHANGELOG.md` myself.