### PR TITLE
Harden CI based on zizmor

### DIFF
--- a/.github/workflows/audit-release.yml
+++ b/.github/workflows/audit-release.yml
@@ -75,6 +75,8 @@ jobs:
         id: automation-token
         with:
           client-id: ${{ secrets.AUTOMATION_ID }}
+          permission-actions: write # To trigger another workflow
+          permission-contents: read
           private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
       - name: Trigger new release if main is clean
         if: ${{ failure() }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,8 +10,6 @@ jobs:
   add-to-changelog:
     name: Add specific commit
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write # To push a commit
     if: |
       github.event.issue.pull_request &&
       github.event.comment.user.login == 'ericcornelissen' &&
@@ -28,6 +26,8 @@ jobs:
         id: automation-token
         with:
           client-id: ${{ secrets.AUTOMATION_ID }}
+          permission-contents: write # To push a commit
+          permission-pull-requests: read
           private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
       - name: Parse comment
         id: comment

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -111,7 +111,7 @@ jobs:
     permissions:
       security-events: write # To upload SARIF results
     container:
-      image: semgrep/semgrep:1.162.0
+      image: semgrep/semgrep@sha256:9349edbadf90c3f3c0c3f55867625354e89680e6fa10d9034042af52fdb0e0d0 # 1.162.0
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,15 +35,14 @@ jobs:
   update:
     name: Update Tooling
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write # To push a commit
-      pull-requests: write # To open a Pull Request
     steps:
       - name: Create token to create Pull Request
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: automation-token
         with:
           client-id: ${{ secrets.AUTOMATION_ID }}
+          permission-contents: write # To push a commit
+          permission-pull-requests: write # To open a Pull Request
           private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
       - name: Update tooling
         uses: ericcornelissen/tool-versions-update-action/pr@aa1815a7caf1aecd37208e34ad57bec973bcd507 # v2.2.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,6 @@ jobs:
   initiate:
     name: Initiate
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write # To push a commit
-      pull-requests: write # To open a Pull Request
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -35,6 +32,8 @@ jobs:
         id: automation-token
         with:
           client-id: ${{ secrets.AUTOMATION_ID }}
+          permission-contents: write # To push a commit
+          permission-pull-requests: write # To open a Pull Request
           private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
       - name: Bump version
         env:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -10,9 +10,6 @@ jobs:
   npm-deps:
     name: Update transitive dependencies
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write # To push a commit
-      pull-requests: write # To open a Pull Request
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -28,6 +25,8 @@ jobs:
         id: automation-token
         with:
           client-id: ${{ secrets.AUTOMATION_ID }}
+          permission-contents: write # To push a commit
+          permission-pull-requests: write # To open a Pull Request
           private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
       - name: Install dependencies
         run: npm clean-install


### PR DESCRIPTION
## Before

```
error[github-app]: dangerous use of GitHub App tokens
  --> ./.github/workflows/audit-release.yml:73:15
   |
73 |         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ app token inherits blanket installation permissions
   |
   = note: audit confidence → High
   = tip: specify at least one `permission-<name>` input to limit the token's permissions
   = help: audit documentation → https://docs.zizmor.sh/audits/#github-app

error[github-app]: dangerous use of GitHub App tokens
  --> ./.github/workflows/changelog.yml:27:15
   |
27 |         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ app token inherits blanket installation permissions
   |
   = note: audit confidence → High
   = tip: specify at least one `permission-<name>` input to limit the token's permissions
   = help: audit documentation → https://docs.zizmor.sh/audits/#github-app

error[unpinned-images]: unpinned image references
   --> ./.github/workflows/check.yml:114:7
    |
114 |       image: semgrep/semgrep:1.162.0
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is not pinned to a SHA256 hash
    |
    = note: audit confidence → High
    = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-images

error[github-app]: dangerous use of GitHub App tokens
  --> ./.github/workflows/nightly.yml:43:15
   |
43 |         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ app token inherits blanket installation permissions
   |
   = note: audit confidence → High
   = tip: specify at least one `permission-<name>` input to limit the token's permissions
   = help: audit documentation → https://docs.zizmor.sh/audits/#github-app

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/publish.yml:41:9
   |
41 |         - name: Checkout repository
   |  _________^
42 | |         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
43 | |         with:
44 | |           fetch-depth: 0
   | |________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix
   = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked

error[github-app]: dangerous use of GitHub App tokens
  --> ./.github/workflows/release.yml:34:15
   |
34 |         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ app token inherits blanket installation permissions
   |
   = note: audit confidence → High
   = tip: specify at least one `permission-<name>` input to limit the token's permissions
   = help: audit documentation → https://docs.zizmor.sh/audits/#github-app

error[github-app]: dangerous use of GitHub App tokens
  --> ./.github/workflows/weekly.yml:27:15
   |
27 |         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ app token inherits blanket installation permissions
   |
   = note: audit confidence → High
   = tip: specify at least one `permission-<name>` input to limit the token's permissions
   = help: audit documentation → https://docs.zizmor.sh/audits/#github-app

17 findings (10 suppressed, 1 unsafe fixes): 0 informational, 0 low, 1 medium, 6 high
```

## After

left one warning because here we use the credentials to push updates for two refs.

```
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/publish.yml:41:9
   |
41 |         - name: Checkout repository
   |  _________^
42 | |         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
43 | |         with:
44 | |           fetch-depth: 0
   | |________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix
   = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked

11 findings (10 suppressed, 1 unsafe fixes): 0 informational, 0 low, 1 medium, 0 high
```

## `.zizmor.yml`

```yml
rules:
  concurrency-limits:
    disable: true
  excessive-permissions:
    disable: true # `permissions: read-all` is fine
```