### PR TITLE
Version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
         with:
-          cosign-release: v${{ steps.versions.outputs.cosign }}
+          cosign-release: ${{ steps.versions.outputs.cosign }}
       - name: Install Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Log in to Docker Hub
@@ -150,7 +150,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
         with:
-          cosign-release: v${{ steps.versions.outputs.cosign }}
+          cosign-release: ${{ steps.versions.outputs.cosign }}
       - name: Install Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Log in to GHCR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ Versioning].
 
 - _No changes yet_
 
-## [0.5.2] - 2026-07-26
+## [0.5.3] - 2026-07-26
 
 - (`791f506`) Update dependency @typescript-eslint/parser to v8.65.0.
 - (`2adc44a`) Update transitive dependency brace-expansion to v5.0.8.
+
+NOTE: Release 0.5.2 was skipped due to an unrecoverable continuous delivery
+failure.
 
 ## [0.5.1] - 2026-07-23
 

--- a/Containerfile
+++ b/Containerfile
@@ -16,7 +16,7 @@ FROM docker.io/node:26.5.0-alpine3.24
 
 LABEL org.opencontainers.image.title="js-regex-security-scanner" \
 	org.opencontainers.image.description="A static analyzer to scan JavaScript code for problematic regular expressions." \
-	org.opencontainers.image.version="0.5.2" \
+	org.opencontainers.image.version="0.5.3" \
 	org.opencontainers.image.licenses="Apache-2.0" \
 	org.opencontainers.image.source="https://github.com/ericcornelissen/js-regex-security-scanner"
 


### PR DESCRIPTION
Relates to #1590, #1606, [Publish job #519](https://github.com/ericcornelissen/js-regex-security-scanner/actions/runs/30191269226)